### PR TITLE
feat: version sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 
 ## check:                   runs linters (includes tests)
 .PHONY: check
-check: check-src check-tests
+check: check-src check-tests check-version
 
 ## check-src:               runs linters (source only, no tests)
 .PHONY: check-src
@@ -80,11 +80,22 @@ check-scripts:
     # Fail if any of these files have warnings
 	scripts/shellcheck.sh
 
+## check-version:           run check to ensure version in CHANGELOG.md matches version in package
+.PHONY: check-version
+check-version:
+    # Fail if syncing version would produce changes
+	scripts/version-sync.sh -c -d ${PACKAGE_NAME}
+
 ## tidy:                    run black
 .PHONY: tidy
 tidy:
 	black --line-length 100 ${PACKAGE_NAME}
 	black --line-length 100 test_${PACKAGE_NAME}
+
+## version-sync:            update __version__.py with most recent version from CHANGELOG.md
+.PHONY: version-sync
+version-sync:
+	scripts/version-sync.sh -d ${PACKAGE_NAME}
 
 .PHONY: check-coverage
 check-coverage:

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+function usage {
+    echo "Usage: $(basename "$0") [-c] [-d SOURCE_DIR]" 2>&1
+    echo 'Synchronize __version__.py to latest version in CHANGELOG.md'
+    echo '   -d SOURCE_DIR   Specify location of __version__.py file.'
+    echo '   -c              Compare versions and output proposed changes without changing anything.'
+}
+
+
+CHECK=0
+SOURCE_DIR="."
+while getopts ":hcd:" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        c)
+            CHECK=1
+            ;;
+        d)
+            SOURCE_DIR=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG." >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Version appearing earliest in CHANGELOGFILE will be used as ground truth.
+CHANGELOGFILE="CHANGELOG.md"
+VERSIONFILE="${SOURCE_DIR}/__version__.py"
+RE_SEMVER_FULL="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?"
+# Pull out semver appearing earliest in CHANGELOGFILE.
+LAST_VERSION=$(grep -o -m 1 -E "${RE_SEMVER_FULL}" "$CHANGELOGFILE")
+
+if [ -z "$LAST_VERSION" ];
+then
+    # No match to semver regex in CHANGELOGFILE, so no version to go from.
+    printf "Error: Unable to find latest version from %s.\n" "$CHANGELOGFILE"
+    exit 1
+fi
+
+# Add files to this array that need to be kept in sync.
+FILES_TO_CHANGE=("$VERSIONFILE")
+# Add patterns to this array to be matched in the above files.
+RE_SEMVERS=("$RE_SEMVER_FULL")
+# Add versions to this array to be used as replacements for the patterns matched above from the corresponding files.
+UPDATED_VERSIONS=("$LAST_VERSION")
+
+for i in "${!FILES_TO_CHANGE[@]}"; do
+    FILE_TO_CHANGE=${FILES_TO_CHANGE[$i]}
+    RE_SEMVER=${RE_SEMVERS[$i]}
+    UPDATED_VERSION=${UPDATED_VERSIONS[$i]}
+    FILE_VERSION=$(grep -o -m 1 -E "${RE_SEMVER}" "$FILE_TO_CHANGE")
+    if [ -z "$FILE_VERSION" ];
+    then
+        # No match to semver regex in VERSIONFILE, so nothing to replace
+        printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
+        exit 1
+    else
+        # Replace semver in VERSIONFILE with semver obtained from CHANGELOGFILE
+        TMPFILE=$(mktemp /tmp/new_version.XXXXXX)
+        sed -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
+        if [ $CHECK == 1 ];
+        then
+            DIFF=$(diff "$FILE_TO_CHANGE"  "$TMPFILE" )
+            if [ -z "$DIFF" ];
+            then
+                printf "version sync would make no changes.\n"
+                rm "$TMPFILE"
+                exit 0
+            else
+                printf "version sync would make the following changes:\n%s\n" "$DIFF"
+                rm "$TMPFILE"
+                exit 1
+            fi
+        else
+            cp "$TMPFILE" "$FILE_TO_CHANGE" 
+            rm "$TMPFILE"
+        fi
+    fi
+done


### PR DESCRIPTION
Addresses [Core-280](https://unstructured-ai.atlassian.net/browse/CORE-280).

Similar to [`unstructured` PR #25](https://github.com/Unstructured-IO/unstructured/pull/25), adds a script to check version in `CHANGELOG.md` against version in `__version__.py` or overwrite the latter version. I made a slight change in the script giving an optional variable to specify the location of `__version__.py` so the same script can be used more universally. Same make targets are added, and the check is added to the `make check` target, and consequently becomes part of CI.

The testing instructions are the same as the other PR:

#### Testing:
To check script:
1. Change the version in `__version__.py` to an invalid version.
2. Run `make check-version`.
3. Should fail with an error message indicating valid semver could not be found in `__version__.py`.
4. Run `make version-sync`.
5. Should fail with same error message.
1. Change the version in `__version__.py` to a valid version, that is different from latest version in `CHANGELOG.md`.
2. Run `make check-version`.
3. Should exit 1, reporting diffs that would fix the version in `__version__.py`.
4. Run `make version-sync`.
5. `__version__.py` should now be in sync with `CHANGELOG.md`.
6. Open `CHANGELOG.md` and delete the contents of the file, and save it empty.
7. Run `make check-version`.
8. Should fail with an error message indicating valid semver could not be found in `CHANGELOG.md`.
9. Run `make version-sync`.
10. Should fail with same error message.
11. Undo changes in files.
12. `make check-version` and `make version-sync` should now exit 0 with no changes.