### PR TITLE
chore: Remove unused inspect import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tmp*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0
+## 0.3.0-dev0
 
 * Add the ability to pass Accept MIME type headers to pipeline API's
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev0
+## 0.3.1-dev0
 
 * Add the ability to pass Accept MIME type headers to pipeline API's
 

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0"  # pragma: no cover
+__version__ = "0.3.0-dev0"  # pragma: no cover

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0-dev0"  # pragma: no cover
+__version__ = "0.3.1-dev0"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -4,7 +4,6 @@
 #####################################################################
 
 import os
-import inspect
 from typing import List
 
 from fastapi import status, FastAPI, File, Form, Request, UploadFile


### PR DESCRIPTION
### Summary

- Removes the `import inspect` line from the template because `inspect` no longer happens on the fly
- Updates the `.gitignore` to include temporary files that get generated by the tests