### PR TITLE
chore: fix CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.3.1-dev0
 
+* Dependency bumps
+
+## 0.3.0
+
 * Add the ability to pass Accept MIME type headers to pipeline API's
-
-## 0.2.1-dev1
-
 * Dependency bumps
 
 ## 0.2.0


### PR DESCRIPTION
0.3.0 was released on PyPI, update the CHANGELOG to reflect this.

Also, only the most recent version in the CHANGELOG may be a `-dev` version.