### PR TITLE
fix: Remove ratelimit on the healthcheck endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.3.1-dev0
+## 0.3.1-dev1
 
+* Removed the ratelimit on healthchecks
 * Dependency bumps
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1-dev1
+## 0.3.1
 
 * Removed the ratelimit on healthchecks
 * Dependency bumps

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.1-dev1"  # pragma: no cover
+__version__ = "0.3.1"  # pragma: no cover

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.1-dev0"  # pragma: no cover
+__version__ = "0.3.1-dev1"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -69,7 +69,6 @@ async def pipeline_1(request: Request, file: UploadFile = File(),
     {% endif %}
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-@limiter.limit(RATE_LIMIT)
 async def healthcheck(request: Request):
     return {
         "healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"


### PR DESCRIPTION
### Summary

Removes the rate limit on the healthcheck endpoint. This was causing occasional `429` responses in the deployed healthcheck in ECS.