### PR TITLE
docs: Add developer quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,22 @@ for an example of a repo that uses `unstructured_api_tools`.
 
 ## Installation
 
-You can install the `unstructured_api_tools` library with `pip install unstructured_api_tools`.
-We also provide `make` commands to install the library for local development.
-The `make install-project-local` command installs `unstructured_api_tools` into your local Python
-environment in editable mode. Run `make help` for a full list of install options.
+To install the library, run `pip install unstructured_api_tools`.
+
+## Developer Quick Start
+
+* Using `pyenv` to manage virtualenv's is recommended
+	* Mac install instructions. See [here](https://github.com/Unstructured-IO/community#mac--homebrew) for more detailed instructions.
+		* `brew install pyenv-virtualenv`
+	  * `pyenv install 3.8.13`
+  * Linux instructions are available [here](https://github.com/Unstructured-IO/community#linux).
+
+* Create a virtualenv to work in and activate it, e.g. for one named `unstructured_api_tools`:
+
+	`pyenv  virtualenv 3.8.13 unstructured_api_tools` <br />
+	`pyenv activate unstructured_api_tools`
+
+* Run `make install-project-local`
 
 ## Usage
 


### PR DESCRIPTION
### Summary

Adds a developer quick start section to the README, following the same format as in `pipeline-sec-filings`.