### PR TITLE
fix: get `response_type` value before first call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
         path: |
           .venv
         key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.5
+
+* fix bug to get `response_type` value before first call of it in template
+
 # 0.4.4
 
 * Implement generation of an app-level FastAPI module.

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.4"  # pragma: no cover
+__version__ = "0.4.5"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -87,7 +87,6 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
     expect_other_params = False
 
     supported_optional_params: Dict[str, Union[Type, Tuple]] = {"response_type": str}
-
     for param in params:
         if expect_text_or_file:
             if param == "text":
@@ -134,13 +133,13 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
                     f"Unsupported parameter name {param}, must either be text, file"
                     f', {", ".join(list(supported_optional_params.keys()))}, or begin with m_'
                 )
-
-    return {
+    param_value_map = {
         "multi_string_param_names": multi_string_param_names,
-        "optional_param_value_map": optional_param_value_map,
         "accepts_text": accepts_text,
         "accepts_file": accepts_file,
     }
+    param_value_map = {**param_value_map, **optional_param_value_map}
+    return param_value_map
 
 
 def notebook_file_to_script(

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -87,6 +87,7 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
     expect_other_params = False
 
     supported_optional_params: Dict[str, Union[Type, Tuple]] = {"response_type": str}
+
     for param in params:
         if expect_text_or_file:
             if param == "text":
@@ -133,13 +134,13 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
                     f"Unsupported parameter name {param}, must either be text, file"
                     f', {", ".join(list(supported_optional_params.keys()))}, or begin with m_'
                 )
-    param_value_map = {
+
+    return {
         "multi_string_param_names": multi_string_param_names,
+        "optional_param_value_map": optional_param_value_map,
         "accepts_text": accepts_text,
         "accepts_file": accepts_file,
     }
-    param_value_map = {**param_value_map, **optional_param_value_map}
-    return param_value_map
 
 
 def notebook_file_to_script(

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -19,8 +19,8 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 router = APIRouter()
 
 RATE_LIMIT = os.environ.get("PIPELINE_API_RATE_LIMIT", "1/second")
-{% set response_type = optional_param_value_map.pop("response_type", None) %}
-{% if response_type %}
+{% set default_response_type = optional_param_value_map.pop("response_type", None) %}
+{% if default_response_type %}
 def is_expected_response_type(media_type, response_type):
     if media_type == "application/json" and response_type not in [dict, list]:
         return True
@@ -99,14 +99,14 @@ class MultipartMixedResponse(StreamingResponse):
 async def pipeline_1(request: Request, 
 {% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
-{% if response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
+{% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
 {% for param in multi_string_param_names %}
 {{param}}: List[str] = Form(default=[]),
 {% endfor %}
 ):
     content_type = request.headers.get("Accept")
-{% if response_type %}
-    default_response_type = output_format or "{{response_type}}"
+{% if default_response_type %}
+    default_response_type = output_format or "{{default_response_type}}"
     if not content_type or content_type == "*/*" or content_type == "multipart/mixed":
         media_type = default_response_type
     else:
@@ -139,7 +139,7 @@ async def pipeline_1(request: Request,
                     text=text,
                     file=None,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                    {% if response_type %}response_type=media_type, {% endif %}
+                    {% if default_response_type %}response_type=media_type, {% endif %}
                 )
                 if type(response) not in [str, bytes]:
                     response = json.dumps(response)
@@ -152,7 +152,7 @@ async def pipeline_1(request: Request,
                     text=None,
                     file=_file,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                    {% if response_type %}response_type=media_type, {% endif %}
+                    {% if default_response_type %}response_type=media_type, {% endif %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
                 )
@@ -162,7 +162,7 @@ async def pipeline_1(request: Request,
 
         return MultipartMixedResponse(
             response_generator(), 
-            {% if response_type %}content_type=media_type{% endif %}
+            {% if default_response_type %}content_type=media_type{% endif %}
         )
     else:
         if has_text:
@@ -172,7 +172,7 @@ async def pipeline_1(request: Request,
                 text=text,
                 file=None,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if response_type %}response_type=media_type,{% endif %}
+                {% if default_response_type %}response_type=media_type,{% endif %}
             )
         elif has_files:
             file = files_list[0]
@@ -181,12 +181,12 @@ async def pipeline_1(request: Request,
                 text=None,
                 file=_file,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if response_type %}response_type=media_type,{% endif %}
+                {% if default_response_type %}response_type=media_type,{% endif %}
                 {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                 {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
             )
 
-    {% if response_type %}
+    {% if default_response_type %}
         if is_expected_response_type(media_type, type(response)):
             return PlainTextResponse(
                 content=(f"Conflict in media type {media_type}"
@@ -225,7 +225,7 @@ async def pipeline_1(request: Request,
                     response = pipeline_api(
                         {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
                         {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                        {% if response_type %}response_type=media_type, {% endif %}
+                        {% if default_response_type %}response_type=media_type, {% endif %}
                         {% if accepts_file %}
                             {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                             {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
@@ -237,7 +237,7 @@ async def pipeline_1(request: Request,
             
             return MultipartMixedResponse(
                 response_generator(), 
-                {% if response_type %}content_type=media_type{% endif %}
+                {% if default_response_type %}content_type=media_type{% endif %}
             )
         else:
             {% if accepts_text %}
@@ -251,14 +251,14 @@ async def pipeline_1(request: Request,
             response = pipeline_api(
                 {% if accepts_text %}text, {% elif accepts_file %}_file, {% endif %}
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if response_type %}response_type=media_type,{% endif %}
+                {% if default_response_type %}response_type=media_type,{% endif %}
                 {% if accepts_file %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
                 {% endif %}
             )
 
-            {% if response_type %}
+            {% if default_response_type %}
             if is_expected_response_type(media_type, type(response)):
                 return PlainTextResponse(
                     content=(f"Conflict in media type {media_type}"
@@ -282,13 +282,13 @@ async def pipeline_1(request: Request,
             status_code=status.HTTP_400_BAD_REQUEST
         )
 {% else %}
-    {% if response_type %}
+    {% if default_response_type %}
     response = pipeline_api({% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %} response_type=media_type,)
     {% else %}
     response = pipeline_api({% for param in multi_string_param_names %}{{param}}, {% endfor %})
     {% endif %}
 
-    {% if response_type %}
+    {% if default_response_type %}
     valid_response_types = ["application/json", "text/csv", "*/*"]
     if media_type in valid_response_types:
         return response

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -93,7 +93,7 @@ class MultipartMixedResponse(StreamingResponse):
 {% endif %}
 
 
-
+{% set response_type = optional_param_value_map.pop("response_type", None) %}
 @router.post("{{pipeline_path}}")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(request: Request, 

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -93,7 +93,7 @@ class MultipartMixedResponse(StreamingResponse):
 {% endif %}
 
 
-{% set response_type = optional_param_value_map.pop("response_type", None) %}
+
 @router.post("{{pipeline_path}}")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(request: Request, 

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -19,6 +19,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 router = APIRouter()
 
 RATE_LIMIT = os.environ.get("PIPELINE_API_RATE_LIMIT", "1/second")
+{% set response_type = optional_param_value_map.pop("response_type", None) %}
 {% if response_type %}
 def is_expected_response_type(media_type, response_type):
     if media_type == "application/json" and response_type not in [dict, list]:
@@ -93,7 +94,6 @@ class MultipartMixedResponse(StreamingResponse):
 {% endif %}
 
 
-{% set response_type = optional_param_value_map.pop("response_type", None) %}
 @router.post("{{pipeline_path}}")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(request: Request, 


### PR DESCRIPTION
### Summary
`response_type` is passed in a dict `optional_param_value_map`, we should get its value when we first use it in the template.

### Test
can convert this block in a pipeline notebook to an api script
```
def pipeline_api(text,file, response_type="text/csv", m_subject=[], m_name=[]):
    return {"message": "Got request"}
```
