### PR TITLE
feat: Add support for output_schema parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.6
+
+* Add support for `response_schema` parameter in Pipeline API functions.
+
 # 0.4.5
 
 * fix bug to get `response_type` value before first call of it in template

--- a/test_unstructured_api_tools/pipelines/test_convert.py
+++ b/test_unstructured_api_tools/pipelines/test_convert.py
@@ -137,9 +137,13 @@ def tests_notebook_to_script(sample_notebook):
             "Default argument type for response_type must be one of: <class 'str'>",
         ),
         (
+            "def pipeline_api(text, response_schema=None, m_var=[], m_var2=[]): pass",
+            "Default argument type for response_schema must be one of: <class 'str'>",
+        ),
+        (
             "def pipeline_api(text, m_var=[], m_var2=[], var3=[]): pass",
             "Unsupported parameter name var3, must either be text, file, response_type,"
-            " or begin with m_",
+            " response_schema, or begin with m_",
         ),
         (
             "def pipeline_api(text, m_var=[], file=None, m_var2=[], var3=[]): pass",
@@ -224,6 +228,20 @@ def test_infer_m_params():
             "accepts_file": False,
             "multi_string_param_names": ["var", "var2"],
             "optional_param_value_map": {"response_type": "text/csv"},
+        }
+    )
+
+    assert (
+        convert._infer_params_from_pipeline_api(
+            """def pipeline_api(text, m_var=[], m_var2=[], response_schema="label_studio"):
+        pass
+        """
+        )
+        == {
+            "accepts_text": True,
+            "accepts_file": False,
+            "multi_string_param_names": ["var", "var2"],
+            "optional_param_value_map": {"response_schema": "label_studio"},
         }
     )
 

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.5"  # pragma: no cover
+__version__ = "0.4.6"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -86,7 +86,10 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
     expect_text_or_file = True
     expect_other_params = False
 
-    supported_optional_params: Dict[str, Union[Type, Tuple]] = {"response_type": str}
+    supported_optional_params: Dict[str, Union[Type, Tuple]] = {
+        "response_type": str,
+        "response_schema": str,
+    }
 
     for param in params:
         if expect_text_or_file:

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -93,13 +93,14 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 {% endif %}
 
-
+{% set response_schema = optional_param_value_map.pop("response_schema", None) %}
 @router.post("{{pipeline_path}}")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(request: Request, 
 {% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
+{% if response_schema %}output_schema: str = Form(default=None),{% endif %}
 {% for param in multi_string_param_names %}
 {{param}}: List[str] = Form(default=[]),
 {% endfor %}
@@ -111,6 +112,9 @@ async def pipeline_1(request: Request,
         media_type = default_response_type
     else:
         media_type = content_type
+{% endif %}
+{% if response_schema %}
+    default_response_schema = output_schema or "{{response_schema}}"
 {% endif %}
 
 {% if accepts_text and accepts_file %}
@@ -140,6 +144,7 @@ async def pipeline_1(request: Request,
                     file=None,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
+                    {% if response_schema %}response_schema=default_response_schema, {% endif %}
                 )
                 if type(response) not in [str, bytes]:
                     response = json.dumps(response)
@@ -153,6 +158,7 @@ async def pipeline_1(request: Request,
                     file=_file,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
+                    {% if response_schema %}response_schema=default_response_schema, {% endif %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
                 )
@@ -173,6 +179,7 @@ async def pipeline_1(request: Request,
                 file=None,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
+                {% if response_schema %}response_schema=default_response_schema, {% endif %}
             )
         elif has_files:
             file = files_list[0]
@@ -182,6 +189,7 @@ async def pipeline_1(request: Request,
                 file=_file,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
+                {% if response_schema %}response_schema=default_response_schema, {% endif %}
                 {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                 {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
             )
@@ -226,6 +234,7 @@ async def pipeline_1(request: Request,
                         {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
                         {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                         {% if default_response_type %}response_type=media_type, {% endif %}
+                        {% if response_schema %}response_schema=default_response_schema, {% endif %}
                         {% if accepts_file %}
                             {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                             {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
@@ -252,6 +261,7 @@ async def pipeline_1(request: Request,
                 {% if accepts_text %}text, {% elif accepts_file %}_file, {% endif %}
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
+                {% if response_schema %}response_schema=default_response_schema, {% endif %}
                 {% if accepts_file %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -93,14 +93,14 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 {% endif %}
 
-{% set response_schema = optional_param_value_map.pop("response_schema", None) %}
+{% set default_response_schema = optional_param_value_map.pop("response_schema", None) %}
 @router.post("{{pipeline_path}}")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(request: Request, 
 {% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
-{% if response_schema %}output_schema: str = Form(default=None),{% endif %}
+{% if default_response_schema %}output_schema: str = Form(default=None),{% endif %}
 {% for param in multi_string_param_names %}
 {{param}}: List[str] = Form(default=[]),
 {% endfor %}
@@ -113,8 +113,8 @@ async def pipeline_1(request: Request,
     else:
         media_type = content_type
 {% endif %}
-{% if response_schema %}
-    default_response_schema = output_schema or "{{response_schema}}"
+{% if default_response_schema %}
+    default_response_schema = output_schema or "{{default_response_schema}}"
 {% endif %}
 
 {% if accepts_text and accepts_file %}
@@ -144,7 +144,7 @@ async def pipeline_1(request: Request,
                     file=None,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
-                    {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                    {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                 )
                 if type(response) not in [str, bytes]:
                     response = json.dumps(response)
@@ -158,7 +158,7 @@ async def pipeline_1(request: Request,
                     file=_file,
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
-                    {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                    {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
                 )
@@ -179,7 +179,7 @@ async def pipeline_1(request: Request,
                 file=None,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
             )
         elif has_files:
             file = files_list[0]
@@ -189,7 +189,7 @@ async def pipeline_1(request: Request,
                 file=_file,
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                 {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                 {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
             )
@@ -234,7 +234,7 @@ async def pipeline_1(request: Request,
                         {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
                         {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                         {% if default_response_type %}response_type=media_type, {% endif %}
-                        {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                        {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                         {% if accepts_file %}
                             {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                             {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}
@@ -261,7 +261,7 @@ async def pipeline_1(request: Request,
                 {% if accepts_text %}text, {% elif accepts_file %}_file, {% endif %}
                 {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                 {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if response_schema %}response_schema=default_response_schema, {% endif %}
+                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                 {% if accepts_file %}
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file.content_type, {%endif%}


### PR DESCRIPTION
Resolves https://github.com/Unstructured-IO/community/issues/23

**Summary of changes**
- Add support for `response_schema` parameter in pipeline API functions that is passed in the API request as `output_schema`.
- Update unit tests
- Update version and changelog

**Testing**
- Create a test notebook in `pipeline-sec-filings/pipeline-notebooks` directory called `pipeline-test.ipynb` and paste the following contents:
    ```python
    # pipeline-api
    
    def pipeline_api(text, file=None, m_var=[], response_schema="label_studio"):
        return {"message": f"Returning response with schema: {response_schema}", "var": m_var}
    ```
- Run `make generate-api` and run `PYTHONPATH=. uvicorn prepline_sec_filings.api.test:app --reload`
- Send a request to `http://localhost:8000/sec-filings/v0.2.0/test` with and without `output_schema` parameter to test the functionality.