### PR TITLE
fix: consistent generated code across OS's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 0.4.9-dev0
+# 0.4.9
 
-*  requirements/* bumps (replace this line with the next real CHANGELOG change)
+*  Bug fix: Generated code now consistent across Operating Systems
 
 # 0.4.8
 

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.9-dev0"  # pragma: no cover
+__version__ = "0.4.9"  # pragma: no cover

--- a/unstructured_api_tools/cli.py
+++ b/unstructured_api_tools/cli.py
@@ -32,7 +32,7 @@ def convert_pipeline_notebooks(
 ):
     """Convert a pipeline notebook to a Python script. The conversion script will retain
     any cell that includes # pipeline-api at the top."""
-    notebook_filenames = [f for f in os.listdir(input_directory) if f.endswith(".ipynb")]
+    notebook_filenames = sorted([f for f in os.listdir(input_directory) if f.endswith(".ipynb")])
 
     if flake8_ignore:
         validate_flake8_ignore(flake8_ignore)


### PR DESCRIPTION
Previously, FastAPI code generated by this tool (notably `prepline_<project>/api/app.py`) would produce
slightly different versions when run on Mac vs. Linux. This was due to do the ambiguous ordering of filenames returned
by `os.listdir` in `unstructured_api_tools/cli.py`. Now, the filenames are sorted, so templates dependent on iterating
through filenames are consistent.

Ref:
https://github.com/Unstructured-IO/unstructured-api-tools/blob/c3c08ba/unstructured_api_tools/cli.py#L35 