### PR TITLE
added dynamic docs_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0
+
+* Add dynamic docs_url
+
 # 0.6.0
 
 * Add file type validation via `UNSTRUCTURED_ALLOWED_MIMETYPES`

--- a/test_unstructured_api_tools/api/test_docs.py
+++ b/test_unstructured_api_tools/api/test_docs.py
@@ -1,0 +1,11 @@
+from starlette.testclient import TestClient
+from prepline_test_project.api.app import app
+
+DOCS_ROUTE = "/test-project/docs"
+
+client = TestClient(app)
+
+
+def test_docs():
+    response = client.get(DOCS_ROUTE)
+    assert response.status_code == 200

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -25,6 +25,7 @@ app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
+    docs_url="/test-project/docs",
 )
 
 app.include_router(process_file_1_router)

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.0"  # pragma: no cover
+__version__ = "0.7.0"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -12,7 +12,11 @@ from jinja2 import Environment, FileSystemLoader
 from nbconvert import ScriptExporter
 import nbformat
 
-from unstructured_api_tools.pipelines.api_conventions import get_pipeline_path, PipelineConfig
+from unstructured_api_tools.pipelines.api_conventions import (
+    get_pipeline_path,
+    PipelineConfig,
+    get_api_name_from_config,
+)
 import unstructured_api_tools.pipelines.lint as lint
 
 IMPORT_PATTERN = (
@@ -204,7 +208,11 @@ def build_root_app_module(
         version = ""
 
     content = template.render(
-        module_names=module_names, title=title, description=description, version=version
+        module_names=module_names,
+        title=title,
+        description=description,
+        version=version,
+        version_name=get_api_name_from_config(config_filename),
     )
     content = lint.format_black(content)
     lint.check_flake8(content, opts=flake8_opts)

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -14,6 +14,7 @@ app = FastAPI(
   title="{{ title }}",
   description="""{{ description }}""",
   version="{{ version or '1.0.0' }}",
+  docs_url="{{ '/' ~ version_name ~ '/docs' if version_name else '/docs' }}"
 )
 
 {% for module in module_names -%}


### PR DESCRIPTION
Added dynamic `docs_url`, which is related to `pipeline_family`. If pipeline_family isn't defined, docs_url will equal `/docs`. 
Added test for testing dynamic doc url.
Updated test API.

Bumped version from 0.6.0 to 0.7.0 

Closes issue #146 