### PR TITLE
Add duplicate routes with semver major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+
+* Add duplicate routes with semver major version
+
 # 0.7.0
 
 * Add dynamic docs_url

--- a/test_unstructured_api_tools/api/test_file_apis.py
+++ b/test_unstructured_api_tools/api/test_file_apis.py
@@ -32,7 +32,10 @@ from functions_and_variables import (
 PROCESS_FILE_1_ROUTE = ["/test-project/v1.2.3/process-file-1", "/test-project/v1/process-file-1"]
 
 # Pull this over here for test_supported_mimetypes
-PROCESS_FILE_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-file-1", "/test-project/v1/process-text-file-1"]
+PROCESS_FILE_TEXT_1_ROUTE = [
+    "/test-project/v1.2.3/process-text-file-1",
+    "/test-project/v1/process-text-file-1",
+]
 
 # accepts: files
 PROCESS_FILE_2_ROUTE = ["/test-project/v1.2.3/process-file-2", "/test-project/v1/process-file-2"]
@@ -91,7 +94,7 @@ def _assert_response_for_process_file_2(test_files, response):
 
 
 def _asert_response_for_process_file_3(
-        test_files, response, response_schema, response_type=TEXT_CSV
+    test_files, response, response_schema, response_type=TEXT_CSV
 ):
     def _json_for_one_file(test_file):
         return {
@@ -117,7 +120,7 @@ def _asert_response_for_process_file_3(
 
 
 def _assert_response_for_process_file_4(
-        test_files, response, response_schema, response_type, m_input1
+    test_files, response, response_schema, response_type, m_input1
 ):
     def _json_for_one_file(test_file):
         return {
@@ -139,7 +142,7 @@ def _assert_response_for_process_file_4(
 
 
 def _assert_response_for_process_file_5(
-        test_files, response, response_schema, response_type, m_input1, m_input2
+    test_files, response, response_schema, response_type, m_input1, m_input2
 ):
     def _json_for_one_file(test_file):
         return {
@@ -294,33 +297,33 @@ def test_process_file_4(test_files, response_type, response_schema, m_input1, ex
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_LABELSTUDIO, P_INPUT_1_EMPTY, P_INPUT_2_MULTI, 200),
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_LABELSTUDIO, P_INPUT_1_SINGLE, P_INPUT_2_EMPTY, 200),
         (
-                [FILE_DOCX, FILE_IMAGE],
-                JSON,
-                RESPONSE_SCHEMA_LABELSTUDIO,
-                P_INPUT_1_SINGLE,
-                P_INPUT_2_EMPTY,
-                200,
+            [FILE_DOCX, FILE_IMAGE],
+            JSON,
+            RESPONSE_SCHEMA_LABELSTUDIO,
+            P_INPUT_1_SINGLE,
+            P_INPUT_2_EMPTY,
+            200,
         ),
         (
-                [FILE_DOCX, FILE_IMAGE],
-                JSON,
-                RESPONSE_SCHEMA_LABELSTUDIO,
-                P_INPUT_1_EMPTY,
-                P_INPUT_2_EMPTY,
-                200,
+            [FILE_DOCX, FILE_IMAGE],
+            JSON,
+            RESPONSE_SCHEMA_LABELSTUDIO,
+            P_INPUT_1_EMPTY,
+            P_INPUT_2_EMPTY,
+            200,
         ),
         (
-                [FILE_DOCX, FILE_IMAGE],
-                JSON,
-                RESPONSE_SCHEMA_LABELSTUDIO,
-                P_INPUT_1_MULTI,
-                P_INPUT_2_EMPTY,
-                200,
+            [FILE_DOCX, FILE_IMAGE],
+            JSON,
+            RESPONSE_SCHEMA_LABELSTUDIO,
+            P_INPUT_1_MULTI,
+            P_INPUT_2_EMPTY,
+            200,
         ),
     ],
 )
 def test_process_file_5(
-        test_files, response_type, response_schema, m_input1, m_input2, expected_status
+    test_files, response_type, response_schema, m_input1, m_input2, expected_status
 ):
     for endpoint in PROCESS_FILE_5_ROUTE:
         response = client.post(
@@ -354,8 +357,8 @@ def test_supported_mimetypes():
             files=convert_files_for_api([FILE_DOCX]),
         )
         assert (
-                response.status_code == 400
-                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            response.status_code == 400
+            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
         )
 
         # Sending multiple files
@@ -364,22 +367,21 @@ def test_supported_mimetypes():
             files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
         )
         assert (
-                response.status_code == 400
-                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            response.status_code == 400
+            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
         )
 
         # for process_file_text_endpoint in PROCESS_FILE_TEXT_1_ROUTE:
 
         for process_file_text_endpoint in PROCESS_FILE_TEXT_1_ROUTE:
-
             # Sending one file (in an api that supports text files)
             response = client.post(
                 process_file_text_endpoint,
                 files=convert_files_for_api([FILE_DOCX]),
             )
             assert (
-                    response.status_code == 400
-                    and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+                response.status_code == 400
+                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
             )
 
             # Multiple files (in an api that supports text files)
@@ -388,8 +390,8 @@ def test_supported_mimetypes():
                 files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
             )
             assert (
-                    response.status_code == 400
-                    and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+                response.status_code == 400
+                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
             )
 
     # If the client doesn't set a mimetype, we may just see application/octet-stream
@@ -399,8 +401,8 @@ def test_supported_mimetypes():
         files=[("files", (FILE_DOCX, open(FILE_DOCX, "rb"), "application/octet-stream"))],
     )
     assert (
-            response.status_code == 400
-            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+        response.status_code == 400
+        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
     )
 
     # Finally, allow all file types again

--- a/test_unstructured_api_tools/api/test_file_apis.py
+++ b/test_unstructured_api_tools/api/test_file_apis.py
@@ -1,6 +1,6 @@
 import json
-from base64 import b64decode
 import os
+from base64 import b64decode
 
 import pytest
 from fastapi.testclient import TestClient
@@ -29,22 +29,22 @@ from functions_and_variables import (
 )
 
 # accepts: files, input2
-PROCESS_FILE_1_ROUTE = "/test-project/v1.2.3/process-file-1"
+PROCESS_FILE_1_ROUTE = ["/test-project/v1.2.3/process-file-1", "/test-project/v1/process-file-1"]
 
 # Pull this over here for test_supported_mimetypes
-PROCESS_FILE_TEXT_1_ROUTE = "/test-project/v1.2.3/process-text-file-1"
+PROCESS_FILE_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-file-1", "/test-project/v1/process-text-file-1"]
 
 # accepts: files
-PROCESS_FILE_2_ROUTE = "/test-project/v1.2.3/process-file-2"
+PROCESS_FILE_2_ROUTE = ["/test-project/v1.2.3/process-file-2", "/test-project/v1/process-file-2"]
 
 # accepts: files, response_type, response_schema
-PROCESS_FILE_3_ROUTE = "/test-project/v1.2.3/process-file-3"
+PROCESS_FILE_3_ROUTE = ["/test-project/v1.2.3/process-file-3", "/test-project/v1/process-file-3"]
 
 # accepts: files, response_type, response_schema, input1
-PROCESS_FILE_4_ROUTE = "/test-project/v1.2.3/process-file-4"
+PROCESS_FILE_4_ROUTE = ["/test-project/v1.2.3/process-file-4", "/test-project/v1/process-file-4"]
 
 # accepts: files, response_type, response_schema, input1, input2
-PROCESS_FILE_5_ROUTE = "/test-project/v1.2.3/process-file-5"
+PROCESS_FILE_5_ROUTE = ["/test-project/v1.2.3/process-file-5", "/test-project/v1/process-file-5"]
 
 client = TestClient(app)
 
@@ -91,7 +91,7 @@ def _assert_response_for_process_file_2(test_files, response):
 
 
 def _asert_response_for_process_file_3(
-    test_files, response, response_schema, response_type=TEXT_CSV
+        test_files, response, response_schema, response_type=TEXT_CSV
 ):
     def _json_for_one_file(test_file):
         return {
@@ -117,7 +117,7 @@ def _asert_response_for_process_file_3(
 
 
 def _assert_response_for_process_file_4(
-    test_files, response, response_schema, response_type, m_input1
+        test_files, response, response_schema, response_type, m_input1
 ):
     def _json_for_one_file(test_file):
         return {
@@ -139,7 +139,7 @@ def _assert_response_for_process_file_4(
 
 
 def _assert_response_for_process_file_5(
-    test_files, response, response_schema, response_type, m_input1, m_input2
+        test_files, response, response_schema, response_type, m_input1, m_input2
 ):
     def _json_for_one_file(test_file):
         return {
@@ -180,29 +180,31 @@ def _assert_response_for_process_file_5(
     ],
 )
 def test_process_file_1(test_files, test_params, test_type_header, expected_status):
-    response = client.post(
-        PROCESS_FILE_1_ROUTE,
-        files=convert_files_for_api(test_files),
-        data=test_params,
-        **generate_header_kwargs(test_type_header),
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        if test_type_header == MIXED:
-            assert response.headers["content-type"].startswith("multipart/mixed; boundary=")
-        else:
-            assert response.headers["content-type"] == test_type_header
-        _assert_response_for_process_file_1(test_files, test_params, test_type_header, response)
+    for endpoint in PROCESS_FILE_1_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files),
+            data=test_params,
+            **generate_header_kwargs(test_type_header),
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            if test_type_header == MIXED:
+                assert response.headers["content-type"].startswith("multipart/mixed; boundary=")
+            else:
+                assert response.headers["content-type"] == test_type_header
+            _assert_response_for_process_file_1(test_files, test_params, test_type_header, response)
 
 
 @pytest.mark.parametrize(
     "test_files,expected_status", [([FILE_DOCX], 200), ([FILE_DOCX, FILE_IMAGE], 200)]
 )
 def test_process_file_2(test_files, expected_status):
-    response = client.post(PROCESS_FILE_2_ROUTE, files=convert_files_for_api(test_files))
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_2(test_files, response)
+    for endpoint in PROCESS_FILE_2_ROUTE:
+        response = client.post(endpoint, files=convert_files_for_api(test_files))
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_2(test_files, response)
 
 
 @pytest.mark.parametrize(
@@ -247,15 +249,16 @@ def test_process_file_2(test_files, expected_status):
     ],
 )
 def test_process_file_3(test_files, response_type, response_schema, expected_status):
-    response = client.post(
-        PROCESS_FILE_3_ROUTE,
-        files=convert_files_for_api(test_files),
-        data={**response_schema, "output_format": response_type},
-        **generate_header_kwargs(response_type),
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _asert_response_for_process_file_3(test_files, response, response_schema, response_type)
+    for endpoint in PROCESS_FILE_3_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files),
+            data={**response_schema, "output_format": response_type},
+            **generate_header_kwargs(response_type),
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _asert_response_for_process_file_3(test_files, response, response_schema, response_type)
 
 
 @pytest.mark.parametrize(
@@ -270,17 +273,18 @@ def test_process_file_3(test_files, response_type, response_schema, expected_sta
     ],
 )
 def test_process_file_4(test_files, response_type, response_schema, m_input1, expected_status):
-    response = client.post(
-        PROCESS_FILE_4_ROUTE,
-        files=convert_files_for_api(test_files),
-        data={**response_schema, **m_input1, "output_format": response_type},
-        **generate_header_kwargs(response_type),
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_4(
-            test_files, response, response_schema, response_type, m_input1
+    for endpoint in PROCESS_FILE_4_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files),
+            data={**response_schema, **m_input1, "output_format": response_type},
+            **generate_header_kwargs(response_type),
         )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_4(
+                test_files, response, response_schema, response_type, m_input1
+            )
 
 
 @pytest.mark.parametrize(
@@ -290,45 +294,46 @@ def test_process_file_4(test_files, response_type, response_schema, m_input1, ex
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_LABELSTUDIO, P_INPUT_1_EMPTY, P_INPUT_2_MULTI, 200),
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_LABELSTUDIO, P_INPUT_1_SINGLE, P_INPUT_2_EMPTY, 200),
         (
-            [FILE_DOCX, FILE_IMAGE],
-            JSON,
-            RESPONSE_SCHEMA_LABELSTUDIO,
-            P_INPUT_1_SINGLE,
-            P_INPUT_2_EMPTY,
-            200,
+                [FILE_DOCX, FILE_IMAGE],
+                JSON,
+                RESPONSE_SCHEMA_LABELSTUDIO,
+                P_INPUT_1_SINGLE,
+                P_INPUT_2_EMPTY,
+                200,
         ),
         (
-            [FILE_DOCX, FILE_IMAGE],
-            JSON,
-            RESPONSE_SCHEMA_LABELSTUDIO,
-            P_INPUT_1_EMPTY,
-            P_INPUT_2_EMPTY,
-            200,
+                [FILE_DOCX, FILE_IMAGE],
+                JSON,
+                RESPONSE_SCHEMA_LABELSTUDIO,
+                P_INPUT_1_EMPTY,
+                P_INPUT_2_EMPTY,
+                200,
         ),
         (
-            [FILE_DOCX, FILE_IMAGE],
-            JSON,
-            RESPONSE_SCHEMA_LABELSTUDIO,
-            P_INPUT_1_MULTI,
-            P_INPUT_2_EMPTY,
-            200,
+                [FILE_DOCX, FILE_IMAGE],
+                JSON,
+                RESPONSE_SCHEMA_LABELSTUDIO,
+                P_INPUT_1_MULTI,
+                P_INPUT_2_EMPTY,
+                200,
         ),
     ],
 )
 def test_process_file_5(
-    test_files, response_type, response_schema, m_input1, m_input2, expected_status
+        test_files, response_type, response_schema, m_input1, m_input2, expected_status
 ):
-    response = client.post(
-        PROCESS_FILE_5_ROUTE,
-        files=convert_files_for_api(test_files),
-        data={**response_schema, **m_input1, **m_input2, "output_format": response_type},
-        **generate_header_kwargs(response_type),
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_5(
-            test_files, response, response_schema, response_type, m_input1, m_input2
+    for endpoint in PROCESS_FILE_5_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files),
+            data={**response_schema, **m_input1, **m_input2, "output_format": response_type},
+            **generate_header_kwargs(response_type),
         )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_5(
+                test_files, response, response_schema, response_type, m_input1, m_input2
+            )
 
 
 def test_supported_mimetypes():
@@ -342,55 +347,60 @@ def test_supported_mimetypes():
     # Let's disallow docx and make sure we get the right error in each case
     os.environ["UNSTRUCTURED_ALLOWED_MIMETYPES"] = "image/jpeg"
 
-    # Sending one file
-    response = client.post(
-        PROCESS_FILE_1_ROUTE,
-        files=convert_files_for_api([FILE_DOCX]),
-    )
-    assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
-    )
+    for process_file_endpoint in PROCESS_FILE_1_ROUTE:
+        # Sending one file
+        response = client.post(
+            process_file_endpoint,
+            files=convert_files_for_api([FILE_DOCX]),
+        )
+        assert (
+                response.status_code == 400
+                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+        )
 
-    # Sending multiple files
-    response = client.post(
-        PROCESS_FILE_1_ROUTE,
-        files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
-    )
-    assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
-    )
+        # Sending multiple files
+        response = client.post(
+            process_file_endpoint,
+            files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
+        )
+        assert (
+                response.status_code == 400
+                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+        )
 
-    # Sending one file (in an api that supports text files)
-    response = client.post(
-        PROCESS_FILE_TEXT_1_ROUTE,
-        files=convert_files_for_api([FILE_DOCX]),
-    )
-    assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
-    )
+        # for process_file_text_endpoint in PROCESS_FILE_TEXT_1_ROUTE:
 
-    # Multiple files (in an api that supports text files)
-    response = client.post(
-        PROCESS_FILE_TEXT_1_ROUTE,
-        files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
-    )
-    assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
-    )
+        for process_file_text_endpoint in PROCESS_FILE_TEXT_1_ROUTE:
+
+            # Sending one file (in an api that supports text files)
+            response = client.post(
+                process_file_text_endpoint,
+                files=convert_files_for_api([FILE_DOCX]),
+            )
+            assert (
+                    response.status_code == 400
+                    and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            )
+
+            # Multiple files (in an api that supports text files)
+            response = client.post(
+                process_file_text_endpoint,
+                files=convert_files_for_api([FILE_DOCX, FILE_IMAGE]),
+            )
+            assert (
+                    response.status_code == 400
+                    and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            )
 
     # If the client doesn't set a mimetype, we may just see application/octet-stream
     # Here we get the mimetype from the file extension
     response = client.post(
-        PROCESS_FILE_1_ROUTE,
+        process_file_endpoint,
         files=[("files", (FILE_DOCX, open(FILE_DOCX, "rb"), "application/octet-stream"))],
     )
     assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            response.status_code == 400
+            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
     )
 
     # Finally, allow all file types again
@@ -398,7 +408,7 @@ def test_supported_mimetypes():
     del os.environ["UNSTRUCTURED_ALLOWED_MIMETYPES"]
 
     response = client.post(
-        PROCESS_FILE_1_ROUTE,
+        process_file_endpoint,
         files=convert_files_for_api([FILE_DOCX]),
     )
     assert response.status_code == 200

--- a/test_unstructured_api_tools/api/test_file_text_apis.py
+++ b/test_unstructured_api_tools/api/test_file_text_apis.py
@@ -28,16 +28,28 @@ from test_unstructured_api_tools.api.functions_and_variables import (
 )
 
 # accepts: files, text files
-PROCESS_FILE_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-file-1", "/test-project/v1/process-text-file-1"]
+PROCESS_FILE_TEXT_1_ROUTE = [
+    "/test-project/v1.2.3/process-text-file-1",
+    "/test-project/v1/process-text-file-1",
+]
 
 # accepts: files, text files, response_type, input2
-PROCESS_FILE_TEXT_2_ROUTE = ["/test-project/v1.2.3/process-text-file-2", "/test-project/v1/process-text-file-2"]
+PROCESS_FILE_TEXT_2_ROUTE = [
+    "/test-project/v1.2.3/process-text-file-2",
+    "/test-project/v1/process-text-file-2",
+]
 
 # accepts: files, text files, response_type, response_schema
-PROCESS_FILE_TEXT_3_ROUTE = ["/test-project/v1.2.3/process-text-file-3", "/test-project/v1/process-text-file-3"]
+PROCESS_FILE_TEXT_3_ROUTE = [
+    "/test-project/v1.2.3/process-text-file-3",
+    "/test-project/v1/process-text-file-3",
+]
 
 # accepts: files, text files, response_type, response_schema, input1, input2
-PROCESS_FILE_TEXT_4_ROUTE = ["/test-project/v1.2.3/process-text-file-4", "/test-project/v1/process-text-file-4"]
+PROCESS_FILE_TEXT_4_ROUTE = [
+    "/test-project/v1.2.3/process-text-file-4",
+    "/test-project/v1/process-text-file-4",
+]
 
 client = TestClient(app)
 

--- a/test_unstructured_api_tools/api/test_file_text_apis.py
+++ b/test_unstructured_api_tools/api/test_file_text_apis.py
@@ -28,16 +28,16 @@ from test_unstructured_api_tools.api.functions_and_variables import (
 )
 
 # accepts: files, text files
-PROCESS_FILE_TEXT_1_ROUTE = "/test-project/v1.2.3/process-text-file-1"
+PROCESS_FILE_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-file-1", "/test-project/v1/process-text-file-1"]
 
 # accepts: files, text files, response_type, input2
-PROCESS_FILE_TEXT_2_ROUTE = "/test-project/v1.2.3/process-text-file-2"
+PROCESS_FILE_TEXT_2_ROUTE = ["/test-project/v1.2.3/process-text-file-2", "/test-project/v1/process-text-file-2"]
 
 # accepts: files, text files, response_type, response_schema
-PROCESS_FILE_TEXT_3_ROUTE = "/test-project/v1.2.3/process-text-file-3"
+PROCESS_FILE_TEXT_3_ROUTE = ["/test-project/v1.2.3/process-text-file-3", "/test-project/v1/process-text-file-3"]
 
 # accepts: files, text files, response_type, response_schema, input1, input2
-PROCESS_FILE_TEXT_4_ROUTE = "/test-project/v1.2.3/process-text-file-4"
+PROCESS_FILE_TEXT_4_ROUTE = ["/test-project/v1.2.3/process-text-file-4", "/test-project/v1/process-text-file-4"]
 
 client = TestClient(app)
 
@@ -241,13 +241,14 @@ def _assert_response_for_process_file_text_4(
     ],
 )
 def test_process_file_text_1(test_files, test_files_text, expected_status):
-    response = client.post(
-        PROCESS_FILE_TEXT_1_ROUTE,
-        files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_text_1(test_files, test_files_text, response)
+    for endpoint in PROCESS_FILE_TEXT_1_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_text_1(test_files, test_files_text, response)
 
 
 @pytest.mark.parametrize(
@@ -264,17 +265,18 @@ def test_process_file_text_1(test_files, test_files_text, expected_status):
     ],
 )
 def test_process_file_text_2(test_files, test_files_text, response_type, m_input2, expected_status):
-    response = client.post(
-        PROCESS_FILE_TEXT_2_ROUTE,
-        files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
-        data={**m_input2, "output_format": response_type},
-        **generate_header_kwargs(response_type)
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_text_2(
-            test_files, test_files_text, response_type, m_input2, response
+    for endpoint in PROCESS_FILE_TEXT_2_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
+            data={**m_input2, "output_format": response_type},
+            **generate_header_kwargs(response_type)
         )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_text_2(
+                test_files, test_files_text, response_type, m_input2, response
+            )
 
 
 @pytest.mark.parametrize(
@@ -301,17 +303,18 @@ def test_process_file_text_2(test_files, test_files_text, response_type, m_input
 def test_process_file_text_3(
     test_files, test_files_text, response_type, response_schema, expected_status
 ):
-    response = client.post(
-        PROCESS_FILE_TEXT_3_ROUTE,
-        files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
-        data={**response_schema, "output_format": response_type},
-        **generate_header_kwargs(response_type)
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_text_3(
-            test_files, test_files_text, response_type, response_schema, response
+    for endpoint in PROCESS_FILE_TEXT_3_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
+            data={**response_schema, "output_format": response_type},
+            **generate_header_kwargs(response_type)
         )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_text_3(
+                test_files, test_files_text, response_type, response_schema, response
+            )
 
 
 @pytest.mark.parametrize(
@@ -394,20 +397,21 @@ def test_process_file_text_3(
 def test_process_file_text_4(
     test_files, test_files_text, response_type, response_schema, m_input1, m_input2, expected_status
 ):
-    response = client.post(
-        PROCESS_FILE_TEXT_4_ROUTE,
-        files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
-        data={**m_input1, **m_input2, **response_schema, "output_format": response_type},
-        **generate_header_kwargs(response_type)
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_file_text_4(
-            test_files,
-            test_files_text,
-            response_type,
-            response_schema,
-            m_input1,
-            m_input2,
-            response,
+    for endpoint in PROCESS_FILE_TEXT_4_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_files_for_api(test_files) + convert_text_files_for_api(test_files_text),
+            data={**m_input1, **m_input2, **response_schema, "output_format": response_type},
+            **generate_header_kwargs(response_type)
         )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_file_text_4(
+                test_files,
+                test_files_text,
+                response_type,
+                response_schema,
+                m_input1,
+                m_input2,
+                response,
+            )

--- a/test_unstructured_api_tools/api/test_text_apis.py
+++ b/test_unstructured_api_tools/api/test_text_apis.py
@@ -26,16 +26,16 @@ from test_unstructured_api_tools.api.functions_and_variables import (
 )
 
 # accepts: text files
-PROCESS_TEXT_1_ROUTE = "/test-project/v1.2.3/process-text-1"
+PROCESS_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-1", "/test-project/v1/process-text-1"]
 
 # accepts: text files, input1, input2
-PROCESS_TEXT_2_ROUTE = "/test-project/v1.2.3/process-text-2"
+PROCESS_TEXT_2_ROUTE = ["/test-project/v1.2.3/process-text-2", "/test-project/v1/process-text-2"]
 
 # accepts: text files, response_type
-PROCESS_TEXT_3_ROUTE = "/test-project/v1.2.3/process-text-3"
+PROCESS_TEXT_3_ROUTE = ["/test-project/v1.2.3/process-text-3", "/test-project/v1/process-text-3"]
 
 # accepts: text files, response_type, response_schema
-PROCESS_TEXT_4_ROUTE = "/test-project/v1.2.3/process-text-4"
+PROCESS_TEXT_4_ROUTE = ["/test-project/v1.2.3/process-text-4", "/test-project/v1/process-text-4"]
 
 client = TestClient(app)
 
@@ -129,10 +129,11 @@ def _assert_response_for_process_text_4(test_files, response, response_type, res
     ],
 )
 def test_process_text_1(test_files, expected_status):
-    response = client.post(PROCESS_TEXT_1_ROUTE, files=convert_text_files_for_api(test_files))
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_text_1(test_files, response)
+    for endpoint in PROCESS_TEXT_1_ROUTE:
+        response = client.post(endpoint, files=convert_text_files_for_api(test_files))
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_text_1(test_files, response)
 
 
 @pytest.mark.parametrize(
@@ -148,14 +149,15 @@ def test_process_text_1(test_files, expected_status):
     ],
 )
 def test_process_text_2(test_files, m_input1, m_input2, expected_status):
-    response = client.post(
-        PROCESS_TEXT_2_ROUTE,
-        files=convert_text_files_for_api(test_files),
-        data={**m_input1, **m_input2},
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_text_2(test_files, response, m_input1, m_input2)
+    for endpoint in PROCESS_TEXT_2_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_text_files_for_api(test_files),
+            data={**m_input1, **m_input2},
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_text_2(test_files, response, m_input1, m_input2)
 
 
 @pytest.mark.parametrize(
@@ -185,15 +187,16 @@ def test_process_text_2(test_files, m_input1, m_input2, expected_status):
     ],
 )
 def test_process_text_3(test_files, response_type, expected_status):
-    response = client.post(
-        PROCESS_TEXT_3_ROUTE,
-        files=convert_text_files_for_api(test_files),
-        data={"output_format": response_type},
-        **generate_header_kwargs(response_type)
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_text_3(test_files, response, response_type)
+    for endpoint in PROCESS_TEXT_3_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_text_files_for_api(test_files),
+            data={"output_format": response_type},
+            **generate_header_kwargs(response_type)
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_text_3(test_files, response, response_type)
 
 
 @pytest.mark.parametrize(
@@ -208,12 +211,13 @@ def test_process_text_3(test_files, response_type, expected_status):
     ],
 )
 def test_process_text_4(test_files, response_type, response_schema, expected_status):
-    response = client.post(
-        PROCESS_TEXT_4_ROUTE,
-        files=convert_text_files_for_api(test_files),
-        data={**response_schema, "output_format": response_type},
-        **generate_header_kwargs(response_type)
-    )
-    assert response.status_code == expected_status
-    if response.status_code == 200:
-        _assert_response_for_process_text_4(test_files, response, response_type, response_schema)
+    for endpoint in PROCESS_TEXT_4_ROUTE:
+        response = client.post(
+            endpoint,
+            files=convert_text_files_for_api(test_files),
+            data={**response_schema, "output_format": response_type},
+            **generate_header_kwargs(response_type)
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            _assert_response_for_process_text_4(test_files, response, response_type, response_schema)

--- a/test_unstructured_api_tools/api/test_text_apis.py
+++ b/test_unstructured_api_tools/api/test_text_apis.py
@@ -220,4 +220,6 @@ def test_process_text_4(test_files, response_type, response_schema, expected_sta
         )
         assert response.status_code == expected_status
         if response.status_code == 200:
-            _assert_response_for_process_text_4(test_files, response, response_type, response_schema)
+            _assert_response_for_process_text_4(
+                test_files, response, response_type, response_schema
+            )

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -195,6 +195,19 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-file-1")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    input2: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        input2=input2,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -179,6 +179,17 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-file-2")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -221,6 +221,21 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-file-3")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        output_format=output_format,
+        output_schema=output_schema,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -238,6 +238,23 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-file-4")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+    input1: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        output_format=output_format,
+        output_schema=output_schema,
+        input1=input1,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -243,6 +243,25 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-file-5")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+    input1: List[str] = Form(default=[]),
+    input2: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        output_format=output_format,
+        output_schema=output_schema,
+        input1=input1,
+        input2=input2,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -178,6 +178,17 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-text-1")
+async def short_pipeline_1(
+    request: Request,
+    text_files: Union[List[UploadFile], None] = File(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        text_files=text_files,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
@@ -185,6 +185,21 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-text-2")
+async def short_pipeline_1(
+    request: Request,
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    input1: List[str] = Form(default=[]),
+    input2: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        text_files=text_files,
+        input1=input1,
+        input2=input2,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -210,6 +210,19 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-text-3")
+async def short_pipeline_1(
+    request: Request,
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        text_files=text_files,
+        output_format=output_format,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -223,6 +223,21 @@ async def pipeline_1(
         )
 
 
+@router.post("/test-project/v1/process-text-4")
+async def short_pipeline_1(
+    request: Request,
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        text_files=text_files,
+        output_format=output_format,
+        output_schema=output_schema,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
@@ -224,6 +224,19 @@ async def pipeline_1(
         return response
 
 
+@router.post("/test-project/v1/process-text-file-1")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    text_files: Union[List[UploadFile], None] = File(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        text_files=text_files,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -268,6 +268,23 @@ async def pipeline_1(
             )
 
 
+@router.post("/test-project/v1/process-text-file-2")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    input2: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        text_files=text_files,
+        output_format=output_format,
+        input2=input2,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -270,6 +270,23 @@ async def pipeline_1(
             )
 
 
+@router.post("/test-project/v1/process-text-file-3")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        text_files=text_files,
+        output_format=output_format,
+        output_schema=output_schema,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -284,6 +284,27 @@ async def pipeline_1(
             )
 
 
+@router.post("/test-project/v1/process-text-file-4")
+async def short_pipeline_1(
+    request: Request,
+    files: Union[List[UploadFile], None] = File(default=None),
+    text_files: Union[List[UploadFile], None] = File(default=None),
+    output_format: Union[str, None] = Form(default=None),
+    output_schema: str = Form(default=None),
+    input1: List[str] = Form(default=[]),
+    input2: List[str] = Form(default=[]),
+):
+    return await pipeline_1(
+        request=request,
+        files=files,
+        text_files=text_files,
+        output_format=output_format,
+        output_schema=output_schema,
+        input1=input1,
+        input2=input2,
+    )
+
+
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipelines/test_api_conventions.py
+++ b/test_unstructured_api_tools/pipelines/test_api_conventions.py
@@ -112,6 +112,14 @@ def test_get_pipeline_path():
     assert path == "/sec-filings/v0.2.1/risk-narrative"
 
 
+def test_get_short_pipeline_path():
+    path = conventions.get_pipeline_path(
+        filename="risk_narrative.py", pipeline_family="sec_filings", semver="0.2.1", shorter=True,
+    )
+
+    assert path == "/sec-filings/v0/risk-narrative"
+
+
 def test_get_pipeline_path_raises_if_either_not_specified():
     with pytest.raises(ValueError):
         conventions.get_pipeline_path(

--- a/test_unstructured_api_tools/pipelines/test_api_conventions.py
+++ b/test_unstructured_api_tools/pipelines/test_api_conventions.py
@@ -114,7 +114,10 @@ def test_get_pipeline_path():
 
 def test_get_short_pipeline_path():
     path = conventions.get_pipeline_path(
-        filename="risk_narrative.py", pipeline_family="sec_filings", semver="0.2.1", shorter=True,
+        filename="risk_narrative.py",
+        pipeline_family="sec_filings",
+        semver="0.2.1",
+        shorter=True,
     )
 
     assert path == "/sec-filings/v0/risk-narrative"

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.0"  # pragma: no cover
+__version__ = "0.8.0"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/api_conventions.py
+++ b/unstructured_api_tools/pipelines/api_conventions.py
@@ -66,6 +66,7 @@ def get_pipeline_path(
     pipeline_family: Optional[str] = None,
     semver: Optional[str] = None,
     config_filename: Optional[str] = None,
+    shorter: Optional[bool] = False,
 ) -> str:
     """Builds the pipeline path according to the conventions outlined in the architecture docs.
     ref: https://github.com/Unstructured-IO/
@@ -88,6 +89,10 @@ def get_pipeline_path(
         semver = str(semver)
 
     raise_for_invalid_semver_string(semver)
+
+    if shorter:
+        semver = semver.split(".")[0]
+
     pipeline_family = pipeline_family.replace("_", "-")
 
     filepath = filename.split("/")

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -51,11 +51,24 @@ def generate_pipeline_api(
         semver=semver,
         config_filename=config_filename,
     )
+
+    short_pipeline_path = get_pipeline_path(
+        filename=get_script_filename(filename),
+        pipeline_family=pipeline_family,
+        semver=semver,
+        config_filename=config_filename,
+        shorter=True,
+    )
     pipeline_api_params = _infer_params_from_pipeline_api(script)
 
     environment = Environment(loader=FileSystemLoader(TEMPLATE_PATH))
     template = environment.get_template("pipeline_api.txt")
-    content = template.render(pipeline_path=pipeline_path, script=script, **pipeline_api_params)
+    content = template.render(
+        pipeline_path=pipeline_path,
+        short_pipeline_path=short_pipeline_path,
+        script=script,
+        **pipeline_api_params,
+    )
     content = _organize_imports(content)
     content = (
         """

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -356,6 +356,26 @@ async def pipeline_1(request: Request,
     {% endif %}
 {% endif %}
 
+@router.post("{{ short_pipeline_path }}")
+async def short_pipeline_1(request: Request,
+{% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
+{% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
+{% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
+{% if default_response_schema %}output_schema: str = Form(default=None),{% endif %}
+{% for param in multi_string_param_names %}
+{{param}}: List[str] = Form(default=[]),
+{% endfor %}
+):
+    return await pipeline_1(request=request,
+{% if accepts_file %}files=files,{% endif %}
+{% if accepts_text %}text_files=text_files,{% endif %}
+{% if default_response_type %}output_format=output_format,{% endif %}
+{% if default_response_schema %}output_schema=output_schema,{% endif %}
+{% for param in multi_string_param_names %}
+{{param}}={{param}},
+{% endfor %}
+)
+
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
 async def healthcheck(request: Request):


### PR DESCRIPTION
Added generating duplicate routes with semver major version. 
Updated tests for endpoints and generating pipeline_path. Added additional test for validating generation shorter pipeline_path.

Bumped version from 0.7.0 to 0.8.0

Closes #147 