### PR TITLE
Remove async/await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.8.1
+
+* Removed async/await from endpoints.
+* Refactored template for generating endpoints with shorter semver.
+
 # 0.8.0
 
 * Add duplicate routes with semver major version

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -44,5 +44,5 @@ app.include_router(process_text_file_4_router)
 
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -127,8 +127,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-file-1")
 @router.post("/test-project/v1.2.3/process-file-1")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     input2: List[str] = Form(default=[]),
@@ -195,21 +196,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-file-1")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    input2: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        input2=input2,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -118,8 +118,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-file-2")
 @router.post("/test-project/v1.2.3/process-file-2")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
 ):
@@ -179,19 +180,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-file-2")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -131,8 +131,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-file-3")
 @router.post("/test-project/v1.2.3/process-file-3")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
@@ -221,23 +222,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-file-3")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        output_format=output_format,
-        output_schema=output_schema,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -143,8 +143,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-file-4")
 @router.post("/test-project/v1.2.3/process-file-4")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
@@ -238,25 +239,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-file-4")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-    input1: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        output_format=output_format,
-        output_schema=output_schema,
-        input1=input1,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -145,8 +145,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-file-5")
 @router.post("/test-project/v1.2.3/process-file-5")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
@@ -243,27 +244,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-file-5")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-    input1: List[str] = Form(default=[]),
-    input2: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        output_format=output_format,
-        output_schema=output_schema,
-        input1=input1,
-        input2=input2,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -119,8 +119,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-1")
 @router.post("/test-project/v1.2.3/process-text-1")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),
 ):
@@ -178,19 +179,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-text-1")
-async def short_pipeline_1(
-    request: Request,
-    text_files: Union[List[UploadFile], None] = File(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        text_files=text_files,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
@@ -120,8 +120,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-2")
 @router.post("/test-project/v1.2.3/process-text-2")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),
     input1: List[str] = Form(default=[]),
@@ -185,23 +186,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-text-2")
-async def short_pipeline_1(
-    request: Request,
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    input1: List[str] = Form(default=[]),
-    input2: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        text_files=text_files,
-        input1=input1,
-        input2=input2,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -127,8 +127,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-3")
 @router.post("/test-project/v1.2.3/process-text-3")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
@@ -210,21 +211,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-text-3")
-async def short_pipeline_1(
-    request: Request,
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        text_files=text_files,
-        output_format=output_format,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -135,8 +135,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-4")
 @router.post("/test-project/v1.2.3/process-text-4")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
@@ -223,23 +224,8 @@ async def pipeline_1(
         )
 
 
-@router.post("/test-project/v1/process-text-4")
-async def short_pipeline_1(
-    request: Request,
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        text_files=text_files,
-        output_format=output_format,
-        output_schema=output_schema,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
@@ -133,8 +133,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-file-1")
 @router.post("/test-project/v1.2.3/process-text-file-1")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     text_files: Union[List[UploadFile], None] = File(default=None),
@@ -224,21 +225,8 @@ async def pipeline_1(
         return response
 
 
-@router.post("/test-project/v1/process-text-file-1")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    text_files: Union[List[UploadFile], None] = File(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        text_files=text_files,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -146,8 +146,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-file-2")
 @router.post("/test-project/v1.2.3/process-text-file-2")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     text_files: Union[List[UploadFile], None] = File(default=None),
@@ -268,25 +269,8 @@ async def pipeline_1(
             )
 
 
-@router.post("/test-project/v1/process-text-file-2")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    input2: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        text_files=text_files,
-        output_format=output_format,
-        input2=input2,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -146,8 +146,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-file-3")
 @router.post("/test-project/v1.2.3/process-text-file-3")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     text_files: Union[List[UploadFile], None] = File(default=None),
@@ -270,25 +271,8 @@ async def pipeline_1(
             )
 
 
-@router.post("/test-project/v1/process-text-file-3")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        text_files=text_files,
-        output_format=output_format,
-        output_schema=output_schema,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -150,8 +150,9 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@router.post("/test-project/v1/process-text-file-4")
 @router.post("/test-project/v1.2.3/process-text-file-4")
-async def pipeline_1(
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     text_files: Union[List[UploadFile], None] = File(default=None),
@@ -284,29 +285,8 @@ async def pipeline_1(
             )
 
 
-@router.post("/test-project/v1/process-text-file-4")
-async def short_pipeline_1(
-    request: Request,
-    files: Union[List[UploadFile], None] = File(default=None),
-    text_files: Union[List[UploadFile], None] = File(default=None),
-    output_format: Union[str, None] = Form(default=None),
-    output_schema: str = Form(default=None),
-    input1: List[str] = Form(default=[]),
-    input2: List[str] = Form(default=[]),
-):
-    return await pipeline_1(
-        request=request,
-        files=files,
-        text_files=text_files,
-        output_format=output_format,
-        output_schema=output_schema,
-        input1=input1,
-        input2=input2,
-    )
-
-
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.0"  # pragma: no cover
+__version__ = "0.8.1"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -106,8 +106,9 @@ class MultipartMixedResponse(StreamingResponse):
 {% endif %}
 
 {% set default_response_schema = optional_param_value_map.pop("response_schema", None) %}
+@router.post("{{ short_pipeline_path }}")
 @router.post("{{pipeline_path}}")
-async def pipeline_1(request: Request,
+def pipeline_1(request: Request,
 {% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
 {% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
@@ -356,29 +357,9 @@ async def pipeline_1(request: Request,
     {% endif %}
 {% endif %}
 
-@router.post("{{ short_pipeline_path }}")
-async def short_pipeline_1(request: Request,
-{% if accepts_file %}files: Union[List[UploadFile], None] = File(default=None),{% endif %}
-{% if accepts_text %}text_files: Union[List[UploadFile], None] = File(default=None),{% endif %}
-{% if default_response_type %}output_format: Union[str, None] = Form(default=None),{% endif %}
-{% if default_response_schema %}output_schema: str = Form(default=None),{% endif %}
-{% for param in multi_string_param_names %}
-{{param}}: List[str] = Form(default=[]),
-{% endfor %}
-):
-    return await pipeline_1(request=request,
-{% if accepts_file %}files=files,{% endif %}
-{% if accepts_text %}text_files=text_files,{% endif %}
-{% if default_response_type %}output_format=output_format,{% endif %}
-{% if default_response_schema %}output_schema=output_schema,{% endif %}
-{% for param in multi_string_param_names %}
-{{param}}={{param}},
-{% endfor %}
-)
-
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {
         "healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"
     }

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -22,5 +22,5 @@ app.include_router({{ module }}_router)
 {% endfor %}
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}


### PR DESCRIPTION
Removed async/await from endpoints. 
Updated templates for generating test API.
Removed duplicated code from templates for creating additional endpoint with shorter semver (mentioned in comment https://github.com/Unstructured-IO/unstructured-api-tools/pull/149#pullrequestreview-1357536942).

Bump version to 0.8.1