### PR TITLE
fix: standard import ref's accessible in api cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# 0.9.1
+
+* Allow references to standard imports in pipeline cells
+
 # 0.9.0
 
 * Add supporting gzip compressed files
-
 
 # 0.8.1
 

--- a/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-1.ipynb
+++ b/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-1.ipynb
@@ -11,11 +11,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d83dab2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7cb5e00b",
    "metadata": {},
    "outputs": [],
    "source": [
     "# pipeline-api\n",
+    "\n",
+    "# test accessing os in a #pipeline-api cell does not break things\n",
+    "_ = os.environ\n",
+    "\n",
     "def pipeline_api(\n",
     "    file,\n",
     "    filename=None,\n",
@@ -30,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "65911889",
    "metadata": {},
    "outputs": [
@@ -56,13 +70,33 @@
     "        )\n",
     "    )"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edce40fa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -32,7 +32,10 @@ app = FastAPI()
 router = APIRouter()
 
 
-# pipeline-api
+# test accessing os in a #pipeline-api cell does not break things
+_ = os.environ
+
+
 def pipeline_api(
     file,
     filename=None,

--- a/test_unstructured_api_tools/pipelines/test_convert.py
+++ b/test_unstructured_api_tools/pipelines/test_convert.py
@@ -108,7 +108,7 @@ def test_get_api_cells(sample_notebook):
 
 
 def tests_notebook_to_script(sample_notebook):
-    script = convert.notebook_to_script(sample_notebook)
+    script, _script_with_standar_imports = convert.notebook_to_script(sample_notebook)
     script_start = "import random\n\n"
 
     assert script.startswith(script_start)

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0"  # pragma: no cover
+__version__ = "0.9.1"  # pragma: no cover


### PR DESCRIPTION
Before this fix, one could not `import os` in a `# pipeline-api` as the resulting FastAPI python module would then have `import os` defined twice. But, in the case where`# pipeline-api` cell had a reference to an `os` module that had been imported previously in a non-`# pipeline-api` cell, an error occurred when converting the notebook since `os` had not been defined (as only `# pipeline-api` cells are inspected, per design).

The fix is to include implied "standard" imports for `os`, `gzip`, `mimetypes`, and `json` when inferring parameters in `pipeline_api`, but not when executing the jinja pipeline-template logic since those imports already exist at the top of the template.