### PR TITLE
chore: add content_type to error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.2
+
+* Add content_type to error message for unsupported file types
+  
 # 0.9.1
 
 * Allow references to standard imports in pipeline cells

--- a/test_unstructured_api_tools/api/test_file_apis.py
+++ b/test_unstructured_api_tools/api/test_file_apis.py
@@ -419,6 +419,11 @@ def test_supported_mimetypes():
     # Let's disallow docx and make sure we get the right error in each case
     os.environ["UNSTRUCTURED_ALLOWED_MIMETYPES"] = "image/jpeg"
 
+    docx_content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    docx_unsupported_error_message = (
+        f"Unable to process {FILE_DOCX}: " f"File type {docx_content_type} is not supported."
+    )
+
     for process_file_endpoint in PROCESS_FILE_1_ROUTE:
         # Sending one file
         response = client.post(
@@ -427,7 +432,7 @@ def test_supported_mimetypes():
         )
         assert (
             response.status_code == 400
-            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            and response.json()["detail"] == docx_unsupported_error_message
         )
 
         # Sending multiple files
@@ -437,7 +442,7 @@ def test_supported_mimetypes():
         )
         assert (
             response.status_code == 400
-            and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+            and response.json()["detail"] == docx_unsupported_error_message
         )
 
         # for process_file_text_endpoint in PROCESS_FILE_TEXT_1_ROUTE:
@@ -450,7 +455,7 @@ def test_supported_mimetypes():
             )
             assert (
                 response.status_code == 400
-                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+                and response.json()["detail"] == docx_unsupported_error_message
             )
 
             # Multiple files (in an api that supports text files)
@@ -460,7 +465,7 @@ def test_supported_mimetypes():
             )
             assert (
                 response.status_code == 400
-                and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+                and response.json()["detail"] == docx_unsupported_error_message
             )
 
     # If the client doesn't set a mimetype, we may just see application/octet-stream
@@ -470,8 +475,7 @@ def test_supported_mimetypes():
         files=[("files", (FILE_DOCX, open(FILE_DOCX, "rb"), "application/octet-stream"))],
     )
     assert (
-        response.status_code == 400
-        and response.json()["detail"] == f"File type not supported: {FILE_DOCX}"
+        response.status_code == 400 and response.json()["detail"] == docx_unsupported_error_message
     )
 
     # Finally, allow all file types again

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -69,7 +69,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -57,7 +57,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -70,7 +70,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -82,7 +82,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -84,7 +84,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -58,7 +58,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
@@ -59,7 +59,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -66,7 +66,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -74,7 +74,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
@@ -72,7 +72,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -85,7 +85,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -85,7 +85,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -89,7 +89,11 @@ def get_validated_mimetype(file):
 
         if content_type not in allowed_mimetypes:
             raise HTTPException(
-                status_code=400, detail=f"File type not supported: {file.filename}"
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
             )
 
     return content_type

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1"  # pragma: no cover
+__version__ = "0.9.2"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -49,7 +49,13 @@ def get_validated_mimetype(file):
         allowed_mimetypes = allowed_mimetypes_str.split(",")
 
         if content_type not in allowed_mimetypes:
-            raise HTTPException(status_code=400, detail=f"File type not supported: {file.filename}")
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                )
+            )
 
     return content_type
 


### PR DESCRIPTION
Currently when a request fails because a file's mimetype is not in UNSTRUCTURED_ALLOWED_MIMETYPES we log an error message with the filename. Debugging issues related to this could be made easier by including the content_type in the error message.

* Adds content_type to error message for unsupported file types
* Updates tests to validate this error message.