### PR TITLE
/healthcheck should not be visible in the /<pipeline-family>/docs #151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# 0.9.3-dev0
+
+* Removed /healthcheck endpoint from docs
+
 # 0.9.2
 
 * Add content_type to error message for unsupported file types
-* Removed /healthcheck endpoint from docs
   
 # 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.9.2
 
 * Add content_type to error message for unsupported file types
+* Removed /healthcheck endpoint from docs
   
 # 0.9.1
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -43,6 +43,6 @@ app.include_router(process_text_file_3_router)
 app.include_router(process_text_file_4_router)
 
 
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
+@app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
 def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.2"  # pragma: no cover
+__version__ = "0.9.3-dev0"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -21,6 +21,6 @@ app = FastAPI(
 app.include_router({{ module }}_router)
 {% endfor %}
 
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
+@app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
 def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}


### PR DESCRIPTION
Removed /healthcheck endpoint from swagger.
Updated template for generating app.py and CHANGELOG.md

---

Closes issue #151 