### PR TITLE
Python versions 3.8, 3.9 and 3.10 should be tested in CI #139

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ env:
 
 jobs:
   setup:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -22,15 +25,15 @@ jobs:
       with:
         path: |
           .venv
-        key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ env.PYTHON_VERSION }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
-        python${{ env.PYTHON_VERSION }} -m venv .venv
+        python${{ matrix.python-version }} -m venv .venv
         source .venv/bin/activate
         make install-ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
         uses: ludeeus/action-shellcheck@master
 
   test_api_consistency:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ubuntu-latest
     needs: [setup, lint]
     steps:
@@ -66,13 +69,16 @@ jobs:
       with:
         path: |
           .venv
-        key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
     - name: API Consistency
       run: |
         source .venv/bin/activate
         make api-check-test
 
   test:
+    strategy:
+      matrix:
+        python-version: [ "3.8", "3.9", "3.10" ]
     runs-on: ubuntu-latest
     needs: test_api_consistency
     steps:
@@ -82,7 +88,7 @@ jobs:
       with:
         path: |
           .venv
-        key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
     - name: Test
       run: |
         source .venv/bin/activate


### PR DESCRIPTION
Added supporting python versions 3.8, 3.9, and 3.10 for CI

---

Closes issue https://github.com/Unstructured-IO/unstructured-api-tools/issues/139