### PR TITLE
fix: handle case where file.content_type is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.9.3-dev0
+# 0.9.3
 
 * Removed /healthcheck endpoint from docs
+* Add fix for handling content type sent as None
 
 # 0.9.2
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -56,7 +56,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -44,7 +44,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -57,7 +57,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -69,7 +69,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -71,7 +71,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -45,7 +45,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
@@ -46,7 +46,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -53,7 +53,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -61,7 +61,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
@@ -59,7 +59,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -72,7 +72,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -72,7 +72,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -76,7 +76,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.3-dev0"  # pragma: no cover
+__version__ = "0.9.3"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -37,7 +37,7 @@ def get_validated_mimetype(file):
     return HTTP 400 for an invalid type.
     """
     content_type = file.content_type
-    if content_type == "application/octet-stream":
+    if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
         # Markdown mimetype is too new for the library - just hardcode that one in for now


### PR DESCRIPTION
I can't reproduce this with the Starlette test client, but the following snippet in a python shell is returning a 400 error from the hosted api.

```
import requests

filename="fake.doc"
with open(filename, "rb") as f:
    response = requests.post(
        "https://api.unstructured.io/general/v0/general",
        files={"files": (str(filename), f)},
    )

print(response.text)
```

When we don't specify the content type in requests, it's causing the FastAPI file.content_type to be
None, at least on my machine.