### PR TITLE
chore: add dynamic openapi_url to mirror docs_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.4
+
+* Add dynamic openapi_url to match docs_url
+
 # 0.9.3
 
 * Removed /healthcheck endpoint from docs

--- a/test_unstructured_api_tools/api/test_docs.py
+++ b/test_unstructured_api_tools/api/test_docs.py
@@ -2,9 +2,15 @@ from starlette.testclient import TestClient
 from prepline_test_project.api.app import app
 
 DOCS_ROUTE = "/test-project/docs"
+OPENAPI_ROUTE = "/test-project/openapi.json"
 HEALTHCHECK_ROUTE = "/healthcheck"
 
 client = TestClient(app)
+
+
+def test_openapi():
+    response = client.get(OPENAPI_ROUTE)
+    assert response.status_code == 200
 
 
 def test_docs():

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -26,6 +26,7 @@ app = FastAPI(
     description="""""",
     version="1.0.0",
     docs_url="/test-project/docs",
+    openapi_url="/test-project/openapi.json",
 )
 
 app.include_router(process_file_1_router)

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.3"  # pragma: no cover
+__version__ = "0.9.4"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -14,7 +14,8 @@ app = FastAPI(
   title="{{ title }}",
   description="""{{ description }}""",
   version="{{ version or '1.0.0' }}",
-  docs_url="{{ '/' ~ version_name ~ '/docs' if version_name else '/docs' }}"
+  docs_url="{{ '/' ~ version_name ~ '/docs' if version_name else '/docs' }}",
+  openapi_url="{{ '/' ~ version_name ~ '/openapi.json' if version_name else '/openapi.json' }}"
 )
 
 {% for module in module_names -%}


### PR DESCRIPTION
For instance, if we want the swagger ui to load at /general/docs, we should make sure the spec is pulled from /general/openapi.json.