### PR TITLE
Ability to request one file as multipart/form data #165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1
+
+* Add Ability to request one file as multipart/form data
+
 # 0.10.0
 
 * Update templates for generated API. 

--- a/test_unstructured_api_tools/api/test_file_apis.py
+++ b/test_unstructured_api_tools/api/test_file_apis.py
@@ -209,8 +209,7 @@ def _assert_response_for_process_file_5(
         ([FILE_IMAGE], P_INPUT_1_AND_2_MULTI, JSON, 200, None),
         ([FILE_DOCX, FILE_IMAGE], P_INPUT_1_AND_2_MULTI, JSON, 200, None),
         ([FILE_DOCX, FILE_IMAGE], P_INPUT_1_AND_2_MULTI, MIXED, 200, None),
-        # json returned though mixed requested (maybe not a bug for 1 file?)
-        pytest.param([FILE_DOCX], P_INPUT_1_MULTI, MIXED, 200, None, marks=pytest.mark.xfail),
+        ([FILE_DOCX], P_INPUT_1_MULTI, MIXED, 200, None),
         # json returned though csv requested
         pytest.param(
             [FILE_IMAGE], P_INPUT_1_AND_2_MULTI, TEXT_CSV, 200, None, marks=pytest.mark.xfail
@@ -309,10 +308,7 @@ def test_process_file_2(
     "gz_content_type",
     [
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_ISD, 200, False, None, None),
-        # endpoint doesn't accept mixed media type for one file
-        pytest.param(
-            [FILE_DOCX], MIXED, RESPONSE_SCHEMA_ISD, 200, False, None, None, marks=pytest.mark.xfail
-        ),
+        ([FILE_DOCX], MIXED, RESPONSE_SCHEMA_ISD, 200, False, None, None),
         # endpoint fails because media type text/csv should have response type str
         pytest.param(
             [FILE_DOCX],
@@ -330,7 +326,6 @@ def test_process_file_2(
             [FILE_DOCX], None, RESPONSE_SCHEMA_ISD, 200, False, None, None, marks=pytest.mark.xfail
         ),
         ([FILE_DOCX], JSON, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
-        # endpoint doesn't accept mixed media type for one file
         pytest.param(
             [FILE_DOCX],
             MIXED,
@@ -339,7 +334,6 @@ def test_process_file_2(
             False,
             None,
             None,
-            marks=pytest.mark.xfail,
         ),
         # endpoint fails because media type text/csv should have response type str
         pytest.param(
@@ -377,7 +371,7 @@ def test_process_file_2(
             None,
             marks=pytest.mark.xfail,
         ),
-        ([FILE_DOCX, FILE_IMAGE], None, RESPONSE_SCHEMA_ISD, 200, False, None, None),
+        ([FILE_DOCX, FILE_IMAGE], None, RESPONSE_SCHEMA_ISD, 406, False, None, None),
         ([FILE_DOCX, FILE_IMAGE], JSON, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
         ([FILE_DOCX, FILE_IMAGE], MIXED, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
         # endpoint fails because text/csv is not acceptable for multiple files
@@ -391,12 +385,12 @@ def test_process_file_2(
             None,
             marks=pytest.mark.xfail,
         ),
-        ([FILE_DOCX, FILE_IMAGE], None, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
+        ([FILE_DOCX, FILE_IMAGE], None, RESPONSE_SCHEMA_LABELSTUDIO, 406, False, None, None),
         (
             [FILE_DOCX, FILE_IMAGE, GZIP_FILE_IMAGE],
             None,
             RESPONSE_SCHEMA_LABELSTUDIO,
-            200,
+            406,
             False,
             None,
             None,
@@ -405,7 +399,7 @@ def test_process_file_2(
             [FILE_DOCX, FILE_IMAGE, GZIP_FILE_DOCX],
             None,
             RESPONSE_SCHEMA_LABELSTUDIO,
-            200,
+            406,
             False,
             None,
             None,
@@ -414,7 +408,7 @@ def test_process_file_2(
             [FILE_DOCX, FILE_IMAGE, GZIP_FILE_IMAGE, GZIP_FILE_DOCX],
             None,
             RESPONSE_SCHEMA_LABELSTUDIO,
-            200,
+            406,
             False,
             None,
             None,
@@ -629,7 +623,7 @@ def test_process_file_3(
             False,
             None,
         ),
-        ([FILE_DOCX], MIXED, RESPONSE_SCHEMA_ISD, P_INPUT_1_SINGLE, 406, None, False, None),
+        ([FILE_DOCX], MIXED, RESPONSE_SCHEMA_ISD, P_INPUT_1_SINGLE, 200, None, False, None),
         ([], MIXED, RESPONSE_SCHEMA_ISD, P_INPUT_1_SINGLE, 400, None, False, None),
         (
             [GZIP_FILE_DOCX],
@@ -914,7 +908,7 @@ def test_process_file_4(
             RESPONSE_SCHEMA_ISD,
             P_INPUT_1_MULTI,
             P_INPUT_2_EMPTY,
-            406,
+            200,
             False,
             None,
             None,

--- a/test_unstructured_api_tools/api/test_file_text_apis.py
+++ b/test_unstructured_api_tools/api/test_file_text_apis.py
@@ -456,7 +456,7 @@ def test_process_file_text_1(
         ([FILE_MARKDOWN], [FILE_TXT_1], TEXT_CSV, P_INPUT_2_MULTI, 406, False, None, None),
         ([], [FILE_TXT_1], JSON, P_INPUT_2_SINGLE, 200, False, None, None),
         ([FILE_DOCX], [], JSON, P_INPUT_2_SINGLE, 200, False, None, None),
-        ([], [FILE_TXT_1], MIXED, P_INPUT_2_EMPTY, 406, False, None, None),
+        ([], [FILE_TXT_1], MIXED, P_INPUT_2_EMPTY, 200, False, None, None),
         (
             [GZIP_FILE_DOCX],
             [FILE_TXT_1],
@@ -687,7 +687,7 @@ def test_process_file_text_2(
         ),
         ([], [FILE_TXT_1], JSON, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
         ([FILE_DOCX], [], JSON, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
-        ([FILE_DOCX], [], MIXED, RESPONSE_SCHEMA_LABELSTUDIO, 406, False, None, None),
+        ([FILE_DOCX], [], MIXED, RESPONSE_SCHEMA_LABELSTUDIO, 200, False, None, None),
         (
             [GZIP_FILE_DOCX],
             [FILE_TXT_1],
@@ -1063,7 +1063,7 @@ def test_process_file_text_3(
             RESPONSE_SCHEMA_LABELSTUDIO,
             P_INPUT_1_EMPTY,
             P_INPUT_2_EMPTY,
-            406,
+            200,
             False,
             None,
             None,

--- a/test_unstructured_api_tools/api/test_text_apis.py
+++ b/test_unstructured_api_tools/api/test_text_apis.py
@@ -390,8 +390,7 @@ def test_process_text_2(
     [
         ([FILE_TXT_1], JSON, 200, False, None, None),
         ([GZIP_FILE_TXT_1], JSON, 200, False, None, None),
-        # endpoint doesn't accept mixed media type for one file
-        pytest.param([FILE_TXT_1], MIXED, 200, False, None, None, marks=pytest.mark.xfail),
+        ([FILE_TXT_1], MIXED, 200, False, None, None),
         # endpoint fails because media type text/csv should have response type str
         pytest.param([FILE_TXT_1], TEXT_CSV, 200, False, None, None, marks=pytest.mark.xfail),
         # endpoint fails because media type text/csv should have response type str
@@ -421,19 +420,18 @@ def test_process_text_2(
             None,
             marks=pytest.mark.xfail,
         ),
-        ([FILE_TXT_1, FILE_TXT_2], None, 200, False, None, None),
+        ([FILE_TXT_1, FILE_TXT_2], None, 406, False, None, None),
         ([FILE_TXT_2], JSON, 200, False, None, None),
         ([GZIP_FILE_TXT_2], JSON, 200, False, None, None),
-        # endpoint doesn't accept mixed media type for one file
-        pytest.param([FILE_TXT_2], MIXED, 200, False, None, None, marks=pytest.mark.xfail),
+        ([FILE_TXT_2], MIXED, 200, False, None, None),
         # endpoint fails because media type text/csv should have response type str
         pytest.param([FILE_TXT_2], TEXT_CSV, 200, False, None, None, marks=pytest.mark.xfail),
         # endpoint fails because media type text/csv should have response type str
         # because None response type has default text/csv value
         pytest.param([FILE_TXT_2], None, 200, False, None, None, marks=pytest.mark.xfail),
-        ([FILE_TXT_2, FILE_MARKDOWN], None, 200, True, None, None),
-        ([FILE_TXT_2, FILE_TXT_1], None, 200, False, FILENAME_FORMATS[FILE_TXT_1], None),
-        ([FILE_TXT_2, FILE_MARKDOWN], None, 400, False, FILENAME_FORMATS[FILE_TXT_1], None),
+        ([FILE_TXT_2, FILE_MARKDOWN], None, 406, True, None, None),
+        ([FILE_TXT_2, FILE_TXT_1], None, 406, False, FILENAME_FORMATS[FILE_TXT_1], None),
+        ([FILE_TXT_2, FILE_MARKDOWN], None, 406, False, FILENAME_FORMATS[FILE_TXT_1], None),
         ([], None, 400, False, None, None),
         ([GZIP_FILE_TXT_1], JSON, 200, False, None, FILENAME_FORMATS[FILE_TXT_1]),
     ],
@@ -513,7 +511,7 @@ def test_process_text_3(
             None,
         ),
         ([FILE_TXT_1, FILE_TXT_2], TEXT_CSV, RESPONSE_SCHEMA_ISD, 406, False, None, None),
-        ([FILE_TXT_1], MIXED, RESPONSE_SCHEMA_ISD, 406, False, None, None),
+        ([FILE_TXT_1], MIXED, RESPONSE_SCHEMA_ISD, 200, False, None, None),
         ([], JSON, RESPONSE_SCHEMA_ISD, 400, False, None, None),
         (
             [GZIP_FILE_TXT_1],

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -168,49 +168,42 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in files:
-                    get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in files:
+                get_validated_mimetype(file)
 
-                    _file = file.file
+                _file = file.file
 
-                    response = pipeline_api(
-                        _file,
-                    )
-                    if is_multipart:
-                        if type(response) not in [str, bytes]:
-                            response = json.dumps(response)
-                    yield response
-
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True),
+                response = pipeline_api(
+                    _file,
                 )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            file = files[0]
-            _file = file.file
 
-            get_validated_mimetype(file)
+                if is_multipart:
+                    if type(response) not in [str, bytes]:
+                        response = json.dumps(response)
+                yield response
 
-            response = pipeline_api(
-                _file,
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True),
             )
-
-            return response
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -191,68 +191,65 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in files:
-                    get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in files:
+                get_validated_mimetype(file)
 
-                    _file = file.file
+                _file = file.file
 
-                    response = pipeline_api(
-                        _file,
-                        response_type=media_type,
-                        response_schema=default_response_schema,
+                response = pipeline_api(
+                    _file,
+                    response_type=media_type,
+                    response_schema=default_response_schema,
+                )
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     )
+
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
                     if is_multipart:
                         if type(response) not in [str, bytes]:
                             response = json.dumps(response)
                     yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True), content_type=media_type
-                )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            file = files[0]
-            _file = file.file
-
-            get_validated_mimetype(file)
-
-            response = pipeline_api(
-                _file,
-                response_type=media_type,
-                response_schema=default_response_schema,
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True), content_type=media_type
             )
-
-            if is_expected_response_type(media_type, type(response)):
-                return PlainTextResponse(
-                    content=(
-                        f"Conflict in media type {media_type}"
-                        f" with response type {type(response)}.\n"
-                    ),
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            valid_response_types = ["application/json", "text/csv", "*/*"]
-            if media_type in valid_response_types:
-                return response
-            else:
-                return PlainTextResponse(
-                    content=f"Unsupported media type {media_type}.\n",
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -204,72 +204,67 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in files:
-                    file_content_type = get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in files:
+                file_content_type = get_validated_mimetype(file)
 
-                    _file = file.file
+                _file = file.file
 
-                    response = pipeline_api(
-                        _file,
-                        m_input1=input1,
-                        response_type=media_type,
-                        response_schema=default_response_schema,
-                        file_content_type=file_content_type,
+                response = pipeline_api(
+                    _file,
+                    m_input1=input1,
+                    response_type=media_type,
+                    response_schema=default_response_schema,
+                    file_content_type=file_content_type,
+                )
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     )
+
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
                     if is_multipart:
                         if type(response) not in [str, bytes]:
                             response = json.dumps(response)
                     yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True), content_type=media_type
-                )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            file = files[0]
-            _file = file.file
-
-            file_content_type = get_validated_mimetype(file)
-
-            response = pipeline_api(
-                _file,
-                m_input1=input1,
-                response_type=media_type,
-                response_schema=default_response_schema,
-                file_content_type=file_content_type,
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True), content_type=media_type
             )
-
-            if is_expected_response_type(media_type, type(response)):
-                return PlainTextResponse(
-                    content=(
-                        f"Conflict in media type {media_type}"
-                        f" with response type {type(response)}.\n"
-                    ),
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            valid_response_types = ["application/json", "text/csv", "*/*"]
-            if media_type in valid_response_types:
-                return response
-            else:
-                return PlainTextResponse(
-                    content=f"Unsupported media type {media_type}.\n",
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -207,74 +207,68 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in files:
-                    file_content_type = get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in files:
+                file_content_type = get_validated_mimetype(file)
 
-                    _file = file.file
+                _file = file.file
 
-                    response = pipeline_api(
-                        _file,
-                        m_input1=input1,
-                        m_input2=input2,
-                        response_type=media_type,
-                        response_schema=default_response_schema,
-                        file_content_type=file_content_type,
+                response = pipeline_api(
+                    _file,
+                    m_input1=input1,
+                    m_input2=input2,
+                    response_type=media_type,
+                    response_schema=default_response_schema,
+                    file_content_type=file_content_type,
+                )
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     )
+
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
                     if is_multipart:
                         if type(response) not in [str, bytes]:
                             response = json.dumps(response)
                     yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True), content_type=media_type
-                )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            file = files[0]
-            _file = file.file
-
-            file_content_type = get_validated_mimetype(file)
-
-            response = pipeline_api(
-                _file,
-                m_input1=input1,
-                m_input2=input2,
-                response_type=media_type,
-                response_schema=default_response_schema,
-                file_content_type=file_content_type,
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True), content_type=media_type
             )
-
-            if is_expected_response_type(media_type, type(response)):
-                return PlainTextResponse(
-                    content=(
-                        f"Conflict in media type {media_type}"
-                        f" with response type {type(response)}.\n"
-                    ),
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            valid_response_types = ["application/json", "text/csv", "*/*"]
-            if media_type in valid_response_types:
-                return response
-            else:
-                return PlainTextResponse(
-                    content=f"Unsupported media type {media_type}.\n",
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -167,47 +167,42 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in text_files:
-                    get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in text_files:
+                get_validated_mimetype(file)
 
-                    text = file.file.read().decode("utf-8")
+                text = file.file.read().decode("utf-8")
 
-                    response = pipeline_api(
-                        text,
-                    )
-                    if is_multipart:
-                        if type(response) not in [str, bytes]:
-                            response = json.dumps(response)
-                    yield response
-
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True),
+                response = pipeline_api(
+                    text,
                 )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            text_file = text_files[0]
-            text = text_file.file.read().decode("utf-8")
 
-            response = pipeline_api(
-                text,
+                if is_multipart:
+                    if type(response) not in [str, bytes]:
+                        response = json.dumps(response)
+                yield response
+
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True),
             )
-
-            return response
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(text_files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "text_files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "text_files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -193,66 +193,65 @@ def pipeline_1(
                 "multipart/mixed",
                 "application/json",
             ]:
-                return PlainTextResponse(
-                    content=(
+                raise HTTPException(
+                    detail=(
                         f"Conflict in media type {content_type}"
                         ' with response type "multipart/mixed".\n'
                     ),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
 
-            def response_generator(is_multipart):
-                for file in text_files:
-                    get_validated_mimetype(file)
+        def response_generator(is_multipart):
+            for file in text_files:
+                get_validated_mimetype(file)
 
-                    text = file.file.read().decode("utf-8")
+                text = file.file.read().decode("utf-8")
 
-                    response = pipeline_api(
-                        text,
-                        response_type=media_type,
-                        response_schema=default_response_schema,
+                response = pipeline_api(
+                    text,
+                    response_type=media_type,
+                    response_schema=default_response_schema,
+                )
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     )
+
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
                     if is_multipart:
                         if type(response) not in [str, bytes]:
                             response = json.dumps(response)
                     yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True), content_type=media_type
-                )
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            text_file = text_files[0]
-            text = text_file.file.read().decode("utf-8")
-
-            response = pipeline_api(
-                text,
-                response_type=media_type,
-                response_schema=default_response_schema,
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True), content_type=media_type
             )
-
-            if is_expected_response_type(media_type, type(response)):
-                return PlainTextResponse(
-                    content=(
-                        f"Conflict in media type {media_type}"
-                        f" with response type {type(response)}.\n"
-                    ),
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            valid_response_types = ["application/json", "text/csv", "*/*"]
-            if media_type in valid_response_types:
-                return response
-            else:
-                return PlainTextResponse(
-                    content=f"Unsupported media type {media_type}.\n",
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-
+        else:
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(text_files) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        return PlainTextResponse(
-            content='Request parameter "text_files" is required.\n',
+        raise HTTPException(
+            detail='Request parameter "text_files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -206,21 +206,28 @@ def pipeline_1(
     has_text = isinstance(text_files, list) and len(text_files)
     has_files = isinstance(files, list) and len(files)
     if not has_text and not has_files:
-        return PlainTextResponse(
-            content='One of the request parameters "text_files" or "files" is required.\n',
+        raise HTTPException(
+            detail='One of the request parameters "text_files" or "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     files_list: List = files or []
     text_files_list: List = text_files or []
 
-    if len(files_list) + len(text_files_list) > 1:
-        if content_type and content_type not in [
-            "*/*",
-            "multipart/mixed",
-            "application/json",
-        ]:
-            return PlainTextResponse(
-                content=(
+    if len(files_list) or len(text_files_list):
+        if all(
+            [
+                content_type,
+                content_type
+                not in [
+                    "*/*",
+                    "multipart/mixed",
+                    "application/json",
+                ],
+                len(files_list) + len(text_files_list) > 1,
+            ]
+        ):
+            raise HTTPException(
+                detail=(
                     f"Conflict in media type {content_type}"
                     ' with response type "multipart/mixed".\n'
                 ),
@@ -237,10 +244,31 @@ def pipeline_1(
                     m_input2=input2,
                     response_type=media_type,
                 )
-                if is_multipart:
-                    if type(response) not in [str, bytes]:
-                        response = json.dumps(response)
-                yield response
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
             for file in files_list:
                 _file = file.file
@@ -255,58 +283,47 @@ def pipeline_1(
                     filename=file.filename,
                     file_content_type=file_content_type,
                 )
-                if is_multipart:
-                    if type(response) not in [str, bytes]:
-                        response = json.dumps(response)
-                yield response
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
         if content_type == "multipart/mixed":
             return MultipartMixedResponse(
                 response_generator(is_multipart=True), content_type=media_type
             )
         else:
-            return response_generator(is_multipart=False)
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files_list + text_files_list) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        if has_text:
-            text_file = text_files_list[0]
-            text = text_file.file.read().decode("utf-8")
-            response = pipeline_api(
-                text=text,
-                file=None,
-                m_input2=input2,
-                response_type=media_type,
-            )
-        elif has_files:
-            file = files_list[0]
-            _file = file.file
-
-            file_content_type = get_validated_mimetype(file)
-
-            response = pipeline_api(
-                text=None,
-                file=_file,
-                m_input2=input2,
-                response_type=media_type,
-                filename=file.filename,
-                file_content_type=file_content_type,
-            )
-
-        if is_expected_response_type(media_type, type(response)):
-            return PlainTextResponse(
-                content=(
-                    f"Conflict in media type {media_type}"
-                    f" with response type {type(response)}.\n"
-                ),
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
-        valid_response_types = ["application/json", "text/csv", "*/*"]
-        if media_type in valid_response_types:
-            return response
-        else:
-            return PlainTextResponse(
-                content=f"Unsupported media type {media_type}.\n",
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
+        raise HTTPException(
+            detail='Request parameters "files" or "text_files" are required.\n',
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 
 
 app.include_router(router)

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -214,21 +214,28 @@ def pipeline_1(
     has_text = isinstance(text_files, list) and len(text_files)
     has_files = isinstance(files, list) and len(files)
     if not has_text and not has_files:
-        return PlainTextResponse(
-            content='One of the request parameters "text_files" or "files" is required.\n',
+        raise HTTPException(
+            detail='One of the request parameters "text_files" or "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     files_list: List = files or []
     text_files_list: List = text_files or []
 
-    if len(files_list) + len(text_files_list) > 1:
-        if content_type and content_type not in [
-            "*/*",
-            "multipart/mixed",
-            "application/json",
-        ]:
-            return PlainTextResponse(
-                content=(
+    if len(files_list) or len(text_files_list):
+        if all(
+            [
+                content_type,
+                content_type
+                not in [
+                    "*/*",
+                    "multipart/mixed",
+                    "application/json",
+                ],
+                len(files_list) + len(text_files_list) > 1,
+            ]
+        ):
+            raise HTTPException(
+                detail=(
                     f"Conflict in media type {content_type}"
                     ' with response type "multipart/mixed".\n'
                 ),
@@ -247,10 +254,31 @@ def pipeline_1(
                     response_type=media_type,
                     response_schema=default_response_schema,
                 )
-                if is_multipart:
-                    if type(response) not in [str, bytes]:
-                        response = json.dumps(response)
-                yield response
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
             for file in files_list:
                 _file = file.file
@@ -267,62 +295,47 @@ def pipeline_1(
                     filename=file.filename,
                     file_content_type=file_content_type,
                 )
-                if is_multipart:
-                    if type(response) not in [str, bytes]:
-                        response = json.dumps(response)
-                yield response
+
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = [
+                    "application/json",
+                    "text/csv",
+                    "*/*",
+                    "multipart/mixed",
+                ]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
 
         if content_type == "multipart/mixed":
             return MultipartMixedResponse(
                 response_generator(is_multipart=True), content_type=media_type
             )
         else:
-            return response_generator(is_multipart=False)
+            return (
+                list(response_generator(is_multipart=False))[0]
+                if len(files_list + text_files_list) == 1
+                else response_generator(is_multipart=False)
+            )
     else:
-        if has_text:
-            text_file = text_files_list[0]
-            text = text_file.file.read().decode("utf-8")
-            response = pipeline_api(
-                text=text,
-                file=None,
-                m_input1=input1,
-                m_input2=input2,
-                response_type=media_type,
-                response_schema=default_response_schema,
-            )
-        elif has_files:
-            file = files_list[0]
-            _file = file.file
-
-            file_content_type = get_validated_mimetype(file)
-
-            response = pipeline_api(
-                text=None,
-                file=_file,
-                m_input1=input1,
-                m_input2=input2,
-                response_type=media_type,
-                response_schema=default_response_schema,
-                filename=file.filename,
-                file_content_type=file_content_type,
-            )
-
-        if is_expected_response_type(media_type, type(response)):
-            return PlainTextResponse(
-                content=(
-                    f"Conflict in media type {media_type}"
-                    f" with response type {type(response)}.\n"
-                ),
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
-        valid_response_types = ["application/json", "text/csv", "*/*"]
-        if media_type in valid_response_types:
-            return response
-        else:
-            return PlainTextResponse(
-                content=f"Unsupported media type {media_type}.\n",
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
+        raise HTTPException(
+            detail='Request parameters "files" or "text_files" are required.\n',
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 
 
 app.include_router(router)

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.0"  # pragma: no cover
+__version__ = "0.10.1"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -177,17 +177,21 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
     has_text = isinstance(text_files, list) and len(text_files)
     has_files = isinstance(files, list) and len(files)
     if not has_text and not has_files:
-        return PlainTextResponse(
-            content="One of the request parameters \"text_files\" or \"files\" is required.\n",
+        raise HTTPException(
+            detail="One of the request parameters \"text_files\" or \"files\" is required.\n",
             status_code=status.HTTP_400_BAD_REQUEST
         )
     files_list: List = files or []
     text_files_list: List = text_files or []
 
-    if len(files_list) + len(text_files_list) > 1:
-        if content_type and content_type not in ["*/*", "multipart/mixed", "application/json"]:
-            return PlainTextResponse(
-                content=(f"Conflict in media type {content_type}"
+    if len(files_list) or len(text_files_list):
+        if all([content_type, content_type not in [
+            "*/*",
+            "multipart/mixed",
+            "application/json",
+        ], len(files_list) + len(text_files_list) > 1]):
+            raise HTTPException(
+                detail=(f"Conflict in media type {content_type}"
                             " with response type \"multipart/mixed\".\n"),
                 status_code=status.HTTP_406_NOT_ACCEPTABLE,
             )
@@ -202,10 +206,32 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
                     {% if default_response_type %}response_type=media_type, {% endif %}
                     {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
                 )
+                {% if default_response_type %}
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = ["application/json", "text/csv", "*/*", "multipart/mixed"]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                {% else %}
                 if is_multipart:
                     if type(response) not in [str, bytes]:
                         response = json.dumps(response)
                 yield response
+                {% endif %}
 
             for file in files_list:
                 _file = file.file
@@ -225,159 +251,117 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
                     {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
                     {% if "file_content_type" in optional_param_value_map %}file_content_type=file_content_type, {%endif%}
                 )
+                {% if default_response_type %}
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                valid_response_types = ["application/json", "text/csv", "*/*", "multipart/mixed"]
+                if media_type in valid_response_types:
+                    if is_multipart:
+                        if type(response) not in [str, bytes]:
+                            response = json.dumps(response)
+                    yield response
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                {% else %}
                 if is_multipart:
                     if type(response) not in [str, bytes]:
                         response = json.dumps(response)
                 yield response
+                {% endif %}
         if content_type == "multipart/mixed":
             return MultipartMixedResponse(
                 response_generator(is_multipart=True),
                 {% if default_response_type %}content_type=media_type{% endif %}
             )
         else:
-            return response_generator(is_multipart=False)
+            return list(response_generator(is_multipart=False))[0] if len(files_list + text_files_list) == 1 else response_generator(is_multipart=False)
     else:
-        if has_text:
-            text_file = text_files_list[0]
-            text = text_file.file.read().decode("utf-8")
-            response = pipeline_api(
-                text=text,
-                file=None,
-                {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
-            )
-        elif has_files:
-            file = files_list[0]
-            _file = file.file
-
-            {% if "file_content_type" in optional_param_value_map %}
-            file_content_type = get_validated_mimetype(file)
-            {% else %}
-            get_validated_mimetype(file)
-            {% endif %}
-
-            response = pipeline_api(
-                text=None,
-                file=_file,
-                {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
-                {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
-                {% if "file_content_type" in optional_param_value_map %}file_content_type=file_content_type, {%endif%}
-            )
-
-    {% if default_response_type %}
-        if is_expected_response_type(media_type, type(response)):
-            return PlainTextResponse(
-                content=(f"Conflict in media type {media_type}"
-                            f" with response type {type(response)}.\n"),
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
-        valid_response_types = ["application/json", "text/csv", "*/*"]
-        if media_type in valid_response_types:
-            return response
-        else:
-            return PlainTextResponse(
-                content=f"Unsupported media type {media_type}.\n",
-                status_code=status.HTTP_406_NOT_ACCEPTABLE,
-            )
-    {% else %}
-        return response
-    {% endif %}
+        raise HTTPException(
+            detail='Request parameters "files" or "text_files" are required.\n',
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 {% elif accepts_text or accepts_file %}
     {% if accepts_text%}{% set var_name = "text_files" %}{% elif accepts_file %}{% set var_name = "files" %}{% endif %}
     if isinstance({{var_name}}, list) and len({{var_name}}):
         if len({{var_name}}) > 1:
             if content_type and content_type not in ["*/*", "multipart/mixed", "application/json"]:
-                return PlainTextResponse(
-                    content=(f"Conflict in media type {content_type}"
+                raise HTTPException(
+                    detail=(f"Conflict in media type {content_type}"
                                 " with response type \"multipart/mixed\".\n"),
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
                 )
-            def response_generator(is_multipart):
-                for file in {{var_name}}:
+        def response_generator(is_multipart):
+            for file in {{var_name}}:
 
-                    {% if "file_content_type" in optional_param_value_map %}
-                    file_content_type = get_validated_mimetype(file)
-                    {% else %}
-                    get_validated_mimetype(file)
+                {% if "file_content_type" in optional_param_value_map %}
+                file_content_type = get_validated_mimetype(file)
+                {% else %}
+                get_validated_mimetype(file)
+                {% endif %}
+
+                {% if accepts_text %}
+                text = file.file.read().decode("utf-8")
+                {% elif accepts_file %}
+                _file = file.file
+                {% endif %}
+
+                response = pipeline_api(
+                    {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
+                    {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
+                    {% if default_response_type %}response_type=media_type, {% endif %}
+                    {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
+                    {% if accepts_file %}
+                        {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
+                        {% if "file_content_type" in optional_param_value_map %}file_content_type=file_content_type, {%endif%}
                     {% endif %}
-
-                    {% if accepts_text %}
-                    text = file.file.read().decode("utf-8")
-                    {% elif accepts_file %}
-                    _file = file.file
-                    {% endif %}
-
-                    response = pipeline_api(
-                        {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
-                        {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                        {% if default_response_type %}response_type=media_type, {% endif %}
-                        {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
-                        {% if accepts_file %}
-                            {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
-                            {% if "file_content_type" in optional_param_value_map %}file_content_type=file_content_type, {%endif%}
-                        {% endif %}
+                )
+                {% if default_response_type %}
+                if is_expected_response_type(media_type, type(response)):
+                    raise HTTPException(
+                        detail=(
+                            f"Conflict in media type {media_type}"
+                            f" with response type {type(response)}.\n"
+                        ),
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
                     )
+
+                valid_response_types = ["application/json", "text/csv", "*/*", "multipart/mixed"]
+                if media_type in valid_response_types:
                     if is_multipart:
                         if type(response) not in [str, bytes]:
                             response = json.dumps(response)
                     yield response
-
-            if content_type == "multipart/mixed":
-                return MultipartMixedResponse(
-                    response_generator(is_multipart=True),
-                    {% if default_response_type %}content_type=media_type{% endif %})
-            else:
-                return response_generator(is_multipart=False)
-        else:
-            {% if accepts_text %}
-            text_file = text_files[0]
-            text = text_file.file.read().decode("utf-8")
-            {% elif accepts_file %}
-            file = files[0]
-            _file = file.file
-
-            {% if "file_content_type" in optional_param_value_map %}
-            file_content_type = get_validated_mimetype(file)
-            {% else %}
-            get_validated_mimetype(file)
-            {% endif %}
-            {% endif %}
-
-            response = pipeline_api(
-                {% if accepts_text %}text, {% elif accepts_file %}_file, {% endif %}
-                {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
-                {% if default_response_type %}response_type=media_type,{% endif %}
-                {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
-                {% if accepts_file %}
-                    {% if "filename" in optional_param_value_map %}filename=file.filename, {%endif%}
-                    {% if "file_content_type" in optional_param_value_map %}file_content_type=file_content_type, {%endif%}
+                else:
+                    raise HTTPException(
+                        detail=f"Unsupported media type {media_type}.\n",
+                        status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    )
+                {% else %}
+                if is_multipart:
+                    if type(response) not in [str, bytes]:
+                        response = json.dumps(response)
+                yield response
                 {% endif %}
-            )
 
-            {% if default_response_type %}
-            if is_expected_response_type(media_type, type(response)):
-                return PlainTextResponse(
-                    content=(f"Conflict in media type {media_type}"
-                                f" with response type {type(response)}.\n"),
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            valid_response_types = ["application/json", "text/csv", "*/*"]
-            if media_type in valid_response_types:
-                return response
-            else:
-                return PlainTextResponse(
-                    content=f"Unsupported media type {media_type}.\n",
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                )
-            {% else %}
-            return response
-            {% endif %}
+
+        if content_type == "multipart/mixed":
+            return MultipartMixedResponse(
+                response_generator(is_multipart=True),
+                {% if default_response_type %}content_type=media_type{% endif %})
+        else:
+            return list(response_generator(is_multipart=False))[0] if len({{var_name}}) == 1 else response_generator(is_multipart=False)
     else:
-        return PlainTextResponse(
-            content="Request parameter \"{{var_name}}\" is required.\n",
+        raise HTTPException(
+            detail="Request parameter \"{{var_name}}\" is required.\n",
             status_code=status.HTTP_400_BAD_REQUEST
         )
 {% else %}
@@ -392,8 +376,8 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
     if media_type in valid_response_types:
         return response
     else:
-        return PlainTextResponse(
-            content=f"Unsupported media type {media_type}.\n",
+        raise HTTPException(
+            detail=f"Unsupported media type {media_type}.\n",
             status_code=status.HTTP_406_NOT_ACCEPTABLE,
         )
     {% else %}


### PR DESCRIPTION
Added ability to request one file as multipart/form data. 

Updated tests and template for generating test API, replaced `return PlainTextResponse` with `raise HTTPException`.

Bump version from 0.10.0 to 0.10.1

---

Closes issue #165 
