### PR TITLE
chore: Filter out logs on /healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.4
+
+* Add filter on /healthcheck logs
+
 # 0.10.3
 
 * Add support for json and msg file types

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -5,6 +5,7 @@
 
 
 from fastapi import FastAPI, Request, status
+import logging
 
 from .process_file_1 import router as process_file_1_router
 from .process_file_2 import router as process_file_2_router
@@ -42,6 +43,15 @@ app.include_router(process_text_file_1_router)
 app.include_router(process_text_file_2_router)
 app.include_router(process_text_file_3_router)
 app.include_router(process_text_file_4_router)
+
+
+# Filter out /healthcheck noise
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find("/healthcheck") == -1
+
+
+logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.3"  # pragma: no cover
+__version__ = "0.10.4"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -5,6 +5,7 @@
 
 
 from fastapi import FastAPI, Request, status
+import logging
 
 {% for module in module_names -%}
 from .{{ module }} import router as {{module}}_router
@@ -21,6 +22,13 @@ app = FastAPI(
 {% for module in module_names -%}
 app.include_router({{ module }}_router)
 {% endfor %}
+
+# Filter out /healthcheck noise
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find("/healthcheck") == -1
+
+logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
 def healthcheck(request: Request):


### PR DESCRIPTION
Reduce noisy uvicorn logs when polling /healthcheck.

To test, you can run a local copy of api-tools to regenerate one of the pipeline apis, and try calling /healthcheck on it.

For instance, in api-tools, run `make install-project-local`. Jump over to unstructured-api and run `make generate-api` and `make run-web-app`. Make a request to localhost:8000/healthcheck and verify that the uvicorn logs do not show it.

Source: https://github.com/encode/starlette/issues/864#issuecomment-653076434