### PR TITLE
chore: updating env var processing for CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.6
+
+* Fix ENV variable processing for CORS
+
 # 0.10.5
 
 * Add optional CORS to api

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/app.py
@@ -37,7 +37,7 @@ if allowed_origins:
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=allowed_origins,
+        allow_origins=allowed_origins.split(","),
         allow_methods=["OPTIONS", "POST"],
         allow_headers=["Content-Type"],
     )

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.5"  # pragma: no cover
+__version__ = "0.10.6"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -22,11 +22,10 @@ app = FastAPI(
 
 allowed_origins = os.environ.get("ALLOWED_ORIGINS", None)
 if allowed_origins:
-    allowed_origins = allowed_origins.split(",")
     from fastapi.middleware.cors import CORSMiddleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=allowed_origins,
+        allow_origins=allowed_origins.split(","),
         allow_methods=["OPTIONS", "POST"],
         allow_headers=["Content-Type"]
         )

--- a/unstructured_api_tools/pipelines/templates/pipeline_app.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_app.txt
@@ -22,6 +22,7 @@ app = FastAPI(
 
 allowed_origins = os.environ.get("ALLOWED_ORIGINS", None)
 if allowed_origins:
+    allowed_origins = allowed_origins.split(",")
     from fastapi.middleware.cors import CORSMiddleware
     app.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
Testing steps!

* activate pyenv for `unstructured-api` (not `-tools`) and cd to root dir of `unstructured-api-tools` to run `pip install -e .` to install the current branch. (should see __version__.py ( 0.10.5 ) from this branch match output from pip list)
* in the `unstructured-api` dir, run make generate-api
* export ALLOWED_ORIGINS="http://example.com/,http://amanda.com" (important that the env var is a comma separated str) and start the app locally with make run-web-app
* run curl and POST and OPTION requests to show the Access-Control-Allow-Origin header being set

example curl request:
should see 200:
```
curl -X OPTIONS -H "Origin: http://example.com" -H "Access-Control-Request-Method: POST" -i http://localhost:8000/general/v0/general

curl -X OPTIONS -H "Origin: http://amanda.com" -H "Access-Control-Request-Method: POST" -i http://localhost:8000/general/v0/general
```

should see 400 (bad cors origin)
```
curl -X OPTIONS -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST" -i http://localhost:8000/general/v0/general
```