### PR TITLE
feat: allow a pipeline to optionally use the FastAPI Request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.7
+
+* Add support for passing request into pipeline
+
 # 0.10.6
 
 * Fix ENV variable processing for CORS

--- a/test_unstructured_api_tools/api/test_file_apis.py
+++ b/test_unstructured_api_tools/api/test_file_apis.py
@@ -45,7 +45,7 @@ PROCESS_FILE_TEXT_1_ROUTE = [
 # accepts: files
 PROCESS_FILE_2_ROUTE = ["/test-project/v1.2.3/process-file-2", "/test-project/v1/process-file-2"]
 
-# accepts: files, response_type, response_schema
+# accepts: files, request, response_type, response_schema
 PROCESS_FILE_3_ROUTE = ["/test-project/v1.2.3/process-file-3", "/test-project/v1/process-file-3"]
 
 # accepts: files, response_type, response_schema, input1

--- a/test_unstructured_api_tools/api/test_file_text_apis.py
+++ b/test_unstructured_api_tools/api/test_file_text_apis.py
@@ -45,7 +45,7 @@ PROCESS_FILE_TEXT_2_ROUTE = [
     "/test-project/v1/process-text-file-2",
 ]
 
-# accepts: files, text files, response_type, response_schema
+# accepts: files, text files, request, response_type, response_schema
 PROCESS_FILE_TEXT_3_ROUTE = [
     "/test-project/v1.2.3/process-text-file-3",
     "/test-project/v1/process-text-file-3",

--- a/test_unstructured_api_tools/api/test_text_apis.py
+++ b/test_unstructured_api_tools/api/test_text_apis.py
@@ -35,7 +35,7 @@ PROCESS_TEXT_1_ROUTE = ["/test-project/v1.2.3/process-text-1", "/test-project/v1
 # accepts: text files, input1, input2
 PROCESS_TEXT_2_ROUTE = ["/test-project/v1.2.3/process-text-2", "/test-project/v1/process-text-2"]
 
-# accepts: text files, response_type
+# accepts: text files, request, response_type
 PROCESS_TEXT_3_ROUTE = ["/test-project/v1.2.3/process-text-3", "/test-project/v1/process-text-3"]
 
 # accepts: text files, response_type, response_schema

--- a/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-3.ipynb
+++ b/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-3.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# pipeline-api\n",
     "def pipeline_api(\n",
-    "    file, response_type=\"text/csv\", response_schema=\"isd\"\n",
+    "    file, request, response_type=\"text/csv\", response_schema=\"isd\"\n",
     "):\n",
     "     return {\"silly_result\": ' : '.join([str(len(file.read())), str(response_type), str(response_schema)])}"
    ]

--- a/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-text-3.ipynb
+++ b/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-text-3.ipynb
@@ -19,6 +19,7 @@
     "# pipeline-api\n",
     "def pipeline_api(\n",
     "    text,\n",
+    "    request,\n",
     "    response_type=\"text/csv\"\n",
     "):\n",
     "    return {\"silly_result\": ' : '.join([str(len(text)), text, str(response_type)])}"

--- a/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-text-file-3.ipynb
+++ b/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-text-file-3.ipynb
@@ -18,6 +18,7 @@
     "# pipeline-api\n",
     "def pipeline_api(\n",
     "    text,\n",
+    "    request,\n",
     "    file=None,\n",
     "    filename=None,\n",
     "    file_content_type=None,\n",

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -33,7 +33,7 @@ def is_expected_response_type(media_type, response_type):
 
 
 # pipeline-api
-def pipeline_api(file, response_type="text/csv", response_schema="isd"):
+def pipeline_api(file, request, response_type="text/csv", response_schema="isd"):
     return {
         "silly_result": " : ".join(
             [str(len(file.read())), str(response_type), str(response_schema)]
@@ -188,6 +188,7 @@ def pipeline_1(
 
                 response = pipeline_api(
                     _file,
+                    request=request,
                     response_type=media_type,
                     response_schema=default_response_schema,
                 )

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -33,7 +33,7 @@ def is_expected_response_type(media_type, response_type):
 
 
 # pipeline-api
-def pipeline_api(text, response_type="text/csv"):
+def pipeline_api(text, request, response_type="text/csv"):
     return {"silly_result": " : ".join([str(len(text)), text, str(response_type)])}
 
 
@@ -181,6 +181,7 @@ def pipeline_1(
 
                 response = pipeline_api(
                     text,
+                    request=request,
                     response_type=media_type,
                 )
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -35,6 +35,7 @@ def is_expected_response_type(media_type, response_type):
 # pipeline-api
 def pipeline_api(
     text,
+    request,
     file=None,
     filename=None,
     file_content_type=None,
@@ -228,6 +229,7 @@ def pipeline_1(
                 response = pipeline_api(
                     text=text,
                     file=None,
+                    request=request,
                     response_type=media_type,
                     response_schema=default_response_schema,
                 )
@@ -260,6 +262,7 @@ def pipeline_1(
                 response = pipeline_api(
                     text=None,
                     file=_file,
+                    request=request,
                     response_type=media_type,
                     response_schema=default_response_schema,
                     filename=file.filename,

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.6"  # pragma: no cover
+__version__ = "0.10.7"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -116,6 +116,7 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
     accepts_file = False
 
     expect_text_or_file = True
+    expect_request_param = False
     expect_other_params = False
 
     supported_optional_params: Dict[str, Union[Type, Tuple]] = {
@@ -135,12 +136,16 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
                 supported_optional_params["file_content_type"] = (str, type(None))
                 expect_other_params = True
                 continue
+            elif param == "request":
+                expect_request_param = True
+                continue
             elif not expect_other_params:
                 raise ValueError("The first parameter(s) must be named either text or file.")
 
-        elif param in ["text", "file"]:
+        elif param in ["text", "file", "request"]:
             raise ValueError(
-                "The parameters text or file must be specified before any keyword parameters."
+                "The parameters text, file, or request, must be "
+                "specified before any keyword parameters."
             )
 
         if expect_other_params:
@@ -175,6 +180,7 @@ def _infer_params_from_pipeline_api(script: str) -> Dict[str, Optional[Any]]:
         "optional_param_value_map": optional_param_value_map,
         "accepts_text": accepts_text,
         "accepts_file": accepts_file,
+        "expect_request_param": expect_request_param,
     }
 
 

--- a/unstructured_api_tools/pipelines/templates/pipeline_api.txt
+++ b/unstructured_api_tools/pipelines/templates/pipeline_api.txt
@@ -206,6 +206,7 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
                 response = pipeline_api(
                     text=text,
                     file=None,
+                    {% if expect_request_param %}request=request, {%endif%}
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
                     {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
@@ -249,6 +250,7 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
                 response = pipeline_api(
                     text=None,
                     file=_file,
+                    {% if expect_request_param %}request=request, {%endif%}
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
                     {% if default_response_schema %}response_schema=default_response_schema, {% endif %}
@@ -320,6 +322,7 @@ gz_uncompressed_content_type: Optional[str] = Form(default=None),
 
                 response = pipeline_api(
                     {% if accepts_text %}text, {% elif accepts_file%}_file, {% endif %}
+                    {% if expect_request_param %}request=request, {%endif%}
                     {% for param in multi_string_param_names %}m_{{param}}={{param}}, {% endfor %}
                     {% if default_response_type %}response_type=media_type, {% endif %}
                     {% if default_response_schema %}response_schema=default_response_schema, {% endif %}


### PR DESCRIPTION
If request is included as a non-default param to pipeline_api, we'll send the active Request object. This will allow a pipeline to, for instance, access headers as needed.

If you'd like to try this:
* Pull this branch
* Active your pyenv for `unstructured-api` and run `make install-project-local`
* Switch to `unstructured-api` and verify that nothing changes when you run `make generate-api`
* Now, open the pipeline notebook and add `request` as a param to `pipeline_api`:
```
def pipeline_api(
    file,
    request,
    filename='',
    m_strategy=[],
    m_coordinates=[],
    file_content_type=None,
    response_type="application/json"
):
```

* Regenerate the api and verify that `general.py` now takes the request param.