### PR TITLE
Add autoflake formatting with duplicate import removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.8
+
+* Add autoflake and duplicate import removal to linting steps
+
 # 0.10.7
 
 * Add support for passing request into pipeline

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ check-src:
 	black --line-length 100 ${PACKAGE_NAME} --check
 	flake8 ${PACKAGE_NAME}
 	mypy ${PACKAGE_NAME} --ignore-missing-imports --install-types --non-interactive
+	autoflake --remove-unused-variables --remove-duplicate-keys --expand-star-imports \
+		--remove-all-unused-imports -cd -r ${PACKAGE_NAME}  test_${PACKAGE_NAME} \
+		--exclude test_${PACKAGE_NAME}/pipeline-test-project
+
 
 .PHONY: check-tests
 check-tests:
@@ -113,9 +117,18 @@ check-version:
 
 ## tidy:                       run black
 .PHONY: tidy
-tidy:
+tidy: tidy-black tidy-autoflake
+
+tidy-autoflake:
+	autoflake --remove-unused-variables --remove-duplicate-keys --expand-star-imports \
+	--remove-all-unused-imports -i -r ${PACKAGE_NAME}  test_${PACKAGE_NAME} \
+	--exclude test_${PACKAGE_NAME}/pipeline-test-project
+
+
+tidy-black:
 	black --line-length 100 ${PACKAGE_NAME}
 	black --line-length 100 test_${PACKAGE_NAME} --exclude test_${PACKAGE_NAME}/pipeline-test-project
+
 
 ## version-sync:               update __version__.py with most recent version from CHANGELOG.md
 .PHONY: version-sync

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,8 @@ anyio==3.6.2
     #   watchfiles
 attrs==22.2.0
     # via jsonschema
+autoflake==2.1.1
+    # via unstructured-api-tools (setup.py)
 beautifulsoup4==4.12.1
     # via nbconvert
 bleach==6.0.0
@@ -80,6 +82,8 @@ platformdirs==3.2.0
     # via jupyter-core
 pydantic==1.10.7
     # via fastapi
+pyflakes==3.0.1
+    # via autoflake
 pygments==2.14.0
     # via nbconvert
 pyrsistent==0.19.3
@@ -107,7 +111,9 @@ starlette==0.26.1
 tinycss2==1.2.1
     # via nbconvert
 tomli==2.0.1
-    # via mypy
+    # via
+    #   autoflake
+    #   mypy
 tornado==6.2
     # via jupyter-client
 traitlets==5.9.0

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "types-requests",
         "types-ujson",
         "uvicorn[standard]",
+        "autoflake"
     ],
     extras_require={},
 )

--- a/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-1.ipynb
+++ b/test_unstructured_api_tools/pipeline-test-project/pipeline-notebooks/pipeline-process-file-1.ipynb
@@ -27,6 +27,9 @@
    "source": [
     "# pipeline-api\n",
     "\n",
+    "# test that a duplicate import gets handles correctly as this gets imported via the template as wel\n",
+    "import json\n",
+    "\n",
     "# test accessing os in a #pipeline-api cell does not break things\n",
     "_ = os.environ\n",
     "\n",

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_1.py
@@ -9,19 +9,20 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 
 app = FastAPI()
 router = APIRouter()
 
+
+# test that a duplicate import gets handles correctly as this gets imported via the template as wel
 
 # test accessing os in a #pipeline-api cell does not break things
 _ = os.environ

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_2.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_3.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_4.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_file_5.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_1.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_2.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_3.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_4.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_1.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_2.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_3.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
+++ b/test_unstructured_api_tools/pipeline-test-project/prepline_test_project/api/process_text_file_4.py
@@ -9,13 +9,12 @@ import gzip
 import mimetypes
 from typing import List, Union
 from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
-from typing import Optional, Mapping, Iterator, Tuple
+from typing import Optional, Mapping
 import secrets
 
 

--- a/unstructured_api_tools/__version__.py
+++ b/unstructured_api_tools/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.7"  # pragma: no cover
+__version__ = "0.10.8"  # pragma: no cover

--- a/unstructured_api_tools/pipelines/convert.py
+++ b/unstructured_api_tools/pipelines/convert.py
@@ -81,6 +81,8 @@ def generate_pipeline_api(
         + content
     )
     content = lint.format_black(content)
+    content = lint.format_autoflake(content)
+    content = lint.remove_duplicate_imports(content)
     lint.check_flake8(content, opts=flake8_opts)
     lint.check_mypy(content)
     return content
@@ -234,6 +236,8 @@ def build_root_app_module(
         version_name=get_api_name_from_config(config_filename),
     )
     content = lint.format_black(content)
+    content = lint.format_autoflake(content)
+    content = lint.remove_duplicate_imports(content)
     lint.check_flake8(content, opts=flake8_opts)
     lint.check_mypy(content)
 

--- a/unstructured_api_tools/pipelines/lint.py
+++ b/unstructured_api_tools/pipelines/lint.py
@@ -4,8 +4,21 @@ import re
 from subprocess import PIPE, Popen
 import tempfile
 from typing import List
+from autoflake import (
+    check,
+    filter_unused_import,
+    SAFE_IMPORTS,
+    unused_import_module_name,
+    filter_useless_pass,
+)
+import pyflakes.api
+import pyflakes.messages
+import pyflakes.reporter
+import io
+import collections
 
 from black import format_str, FileMode
+from autoflake import fix_code
 
 # NOTE(robinson) - F401 is for unused imports
 FLAKE8_DEFAULT_OPTS: List[str] = ["--max-line-length", "100", "--ignore", "F401"]
@@ -100,3 +113,52 @@ def check_black(file_text: str) -> bool:
 def format_black(file_text: str) -> str:
     """Auto-formats a file using black."""
     return format_str(file_text, mode=FileMode(line_length=100))
+
+
+def format_autoflake(file_text: str) -> str:
+    return fix_code(
+        source=file_text,
+        remove_unused_variables=True,
+        remove_all_unused_imports=True,
+        expand_star_imports=True,
+    )
+
+
+# Autoflake only takes into account unused imports by checking for pyflakes.messages.UnusedImport but does not handle
+# duplicate imports which come out as pyflakes.messages.RedefinedWhileUnused from pyflakes. The following code is
+# an extension of autoflake to take duplicate imports into account
+def duplicate_import_line_numbers(messages):
+    """Yield line numbers of unused imports."""
+    for message in messages:
+        if isinstance(message, pyflakes.messages.RedefinedWhileUnused):
+            yield message.lineno
+
+
+def _remove_duplicate_imports(text: str) -> str:
+    messages = check(text)
+    marked_import_line_numbers = frozenset(
+        duplicate_import_line_numbers(messages),
+    )
+    marked_unused_module = collections.defaultdict(lambda: [])
+    for line_number, module_name in unused_import_module_name(messages):
+        marked_unused_module[line_number].append(module_name)
+    sio = io.StringIO(text)
+    previous_line = ""
+    result = None
+    for line_number, line in enumerate(sio.readlines(), start=1):
+        if line_number in marked_import_line_numbers:
+            result = filter_unused_import(
+                line,
+                unused_module=marked_unused_module[line_number],
+                remove_all_unused_imports=True,
+                imports=SAFE_IMPORTS,
+                previous_line=previous_line,
+            )
+        else:
+            result = line
+        yield result
+        previous_line = line
+
+
+def remove_duplicate_imports(text: str) -> str:
+    return "".join(filter_useless_pass("".join(_remove_duplicate_imports(text))))

--- a/unstructured_api_tools/pipelines/lint.py
+++ b/unstructured_api_tools/pipelines/lint.py
@@ -124,9 +124,14 @@ def format_autoflake(file_text: str) -> str:
     )
 
 
-# Autoflake only takes into account unused imports by checking for pyflakes.messages.UnusedImport but does not handle
-# duplicate imports which come out as pyflakes.messages.RedefinedWhileUnused from pyflakes. The following code is
-# an extension of autoflake to take duplicate imports into account
+"""
+Autoflake only takes into account unused imports by checking for pyflakes.messages.UnusedImport
+but does not handle duplicate imports which come out as pyflakes.messages.RedefinedWhileUnused
+from pyflakes. The following code is an extension of autoflake to take duplicate
+imports into account
+"""
+
+
 def duplicate_import_line_numbers(messages):
     """Yield line numbers of unused imports."""
     for message in messages:
@@ -134,7 +139,7 @@ def duplicate_import_line_numbers(messages):
             yield message.lineno
 
 
-def _remove_duplicate_imports(text: str) -> str:
+def _remove_duplicate_imports(text: str):
     messages = check(text)
     marked_import_line_numbers = frozenset(
         duplicate_import_line_numbers(messages),


### PR DESCRIPTION
### Autoflake + duplicate import removal
Right now if the jupyter notebook cell containes an import that was already being added by the template, this would cause a linting error due to duplicate imports. This PR adds in autoflake to run unused import and variable removal as well as provide code to use for removing duplicate imports manually. 